### PR TITLE
don't clear Objects position when Cartesian is set

### DIFF
--- a/src/elements/audio_block_format_objects.cpp
+++ b/src/elements/audio_block_format_objects.cpp
@@ -229,13 +229,14 @@ namespace adm {
   void AudioBlockFormatObjects::set(Rtime rtime) { rtime_ = rtime; }
   void AudioBlockFormatObjects::set(Duration duration) { duration_ = duration; }
   void AudioBlockFormatObjects::set(Cartesian cartesian) {
-    if (isDefault<Cartesian>() || get<Cartesian>() != cartesian) {
-      cartesian_ = cartesian;
-      if (cartesian == true) {
-        set(CartesianPosition());
-      } else {
-        set(SphericalPosition());
-      }
+    cartesian_ = cartesian;
+
+    if (cartesian.get()) {
+      sphericalPosition_ = boost::none;
+      if (!cartesianPosition_) cartesianPosition_ = CartesianPosition();
+    } else {
+      cartesianPosition_ = boost::none;
+      if (!sphericalPosition_) sphericalPosition_ = SphericalPosition();
     }
   }
   void AudioBlockFormatObjects::set(Position position) {
@@ -247,15 +248,15 @@ namespace adm {
   }
   void AudioBlockFormatObjects::set(SphericalPosition position) {
     sphericalPosition_ = position;
-    unset<CartesianPosition>();
-    if (!isDefault<Cartesian>()) {
-      set(Cartesian(false));
+    cartesianPosition_ = boost::none;
+    if (cartesian_ != boost::none) {
+      cartesian_ = Cartesian(false);
     }
   }
   void AudioBlockFormatObjects::set(CartesianPosition position) {
     cartesianPosition_ = position;
-    unset<SphericalPosition>();
-    set(Cartesian(true));
+    sphericalPosition_ = boost::none;
+    cartesian_ = Cartesian(true);
   }
   void AudioBlockFormatObjects::set(Width width) { width_ = width; }
   void AudioBlockFormatObjects::set(Height height) { height_ = height; }

--- a/tests/audio_block_format_objects_tests.cpp
+++ b/tests/audio_block_format_objects_tests.cpp
@@ -129,3 +129,71 @@ TEST_CASE("audio_block_format_objects") {
     REQUIRE(blockFormat.isDefault<Importance>() == true);
   }
 }
+
+TEST_CASE("audio_block_format_objects spherical") {
+  using namespace adm;
+
+  SphericalPosition pos(Azimuth(10.0f), Elevation(0.0f), Distance(1.0f));
+
+  // explicitly set cartesian to default -> no change to position
+  {
+    AudioBlockFormatObjects block_format(pos, Cartesian(false));
+    REQUIRE(block_format.get<SphericalPosition>().get<Azimuth>().get() ==
+            10.0f);
+    REQUIRE(block_format.has<CartesianPosition>() == false);
+    REQUIRE(block_format.get<Cartesian>().get() == false);
+    REQUIRE(block_format.isDefault<Cartesian>() == false);
+  }
+
+  // explicitly set cartesian to non-default -> default position of right type
+  {
+    AudioBlockFormatObjects block_format(pos, Cartesian(true));
+    REQUIRE(block_format.has<SphericalPosition>() == false);
+    REQUIRE(block_format.has<CartesianPosition>() == true);
+    REQUIRE(block_format.get<Cartesian>().get() == true);
+    REQUIRE(block_format.isDefault<Cartesian>() == false);
+  }
+
+  // no set of cartesian -> cartesian is default
+  {
+    AudioBlockFormatObjects block_format(pos);
+    REQUIRE(block_format.get<SphericalPosition>().get<Azimuth>().get() ==
+            10.0f);
+    REQUIRE(block_format.has<CartesianPosition>() == false);
+    REQUIRE(block_format.get<Cartesian>().get() == false);
+    REQUIRE(block_format.isDefault<Cartesian>() == true);
+  }
+}
+
+TEST_CASE("audio_block_format_objects cartesian") {
+  using namespace adm;
+
+  CartesianPosition pos(X(0.1f), Y(0.2f), Z(0.3f));
+
+  // explicitly set cartesian to default -> no change to position
+  {
+    AudioBlockFormatObjects block_format(pos, Cartesian(true));
+    REQUIRE(block_format.get<CartesianPosition>().get<X>().get() == 0.1f);
+    REQUIRE(block_format.has<SphericalPosition>() == false);
+    REQUIRE(block_format.get<Cartesian>().get() == true);
+    REQUIRE(block_format.isDefault<Cartesian>() == false);
+  }
+
+  // explicitly set cartesian to non-default -> default position of right type
+  {
+    AudioBlockFormatObjects block_format(pos, Cartesian(false));
+    REQUIRE(block_format.has<CartesianPosition>() == false);
+    REQUIRE(block_format.has<SphericalPosition>() == true);
+    REQUIRE(block_format.get<Cartesian>().get() == false);
+    REQUIRE(block_format.isDefault<Cartesian>() == false);
+  }
+
+  // no set of cartesian -> still not default
+  {
+    AudioBlockFormatObjects block_format(pos);
+    REQUIRE(block_format.get<CartesianPosition>().get<X>().get() == 0.1f);
+    REQUIRE(block_format.has<SphericalPosition>() == false);
+    REQUIRE(block_format.get<Cartesian>().get() == true);
+    REQUIRE(block_format.isDefault<Cartesian>() == false);
+  }
+}


### PR DESCRIPTION
Fixes #21; see that issue for discussion.

When `set<Cartesian>` was called, the position was cleared if `Cartesian` was defaulted.

This meant that this would have a default position rather than the one specified:

```cpp
AudioBlockFormatObjects(CartesianPosition(...), Cartesian(true))
```

Because `set<CartesianPosition>` also calls `set<Cartesian>`, this would have the same effect:

```cpp
AudioBlockFormatObjects(CartesianPosition(...))
```

To solve this, `set<>` for `Cartesian`, `SphericalPosition` and `CartesianPosition` now all just manipulate `cartesian_`, `sphericalPosition_` and `cartesianPosition_` directly, rather than calling each other.

This isn't the smallest change to fix this, but it does make it obviously correct -- there is no infinite recursion possible here, but before that required a bit of thought.