### PR TITLE
HOA common definitions lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - new `addSimpleCommonDefinitionsObjectTo` function
 - new `addSimpleObjectTo` function
+- added support to lookup HOA common definitions AudioPackFormatIDs and AudioTrackFormatIDs
 
 ### Changed
 

--- a/include/adm/common_definitions.hpp
+++ b/include/adm/common_definitions.hpp
@@ -28,7 +28,7 @@ namespace adm {
    *  - 9+10+3
    *
    * @return Map with the loudspeaker id specified in ITU-R BS.2051 as key and
-   * the corresponding AudioPackFormatId as value.
+   * the corresponding AudioPackFormatID as value.
    */
   ADM_EXPORT const std::map<std::string, adm::AudioPackFormatId>
   audioPackFormatLookupTable();
@@ -46,7 +46,7 @@ namespace adm {
    *  - LFE1, LFE2
    *
    * @return Map with the speaker label specified in ITU-R BS.2051 as key and
-   * the corresponding AudioTrackFormat as value.
+   * the corresponding AudioTrackFormatID as value.
    */
   ADM_EXPORT const std::map<std::string, adm::AudioTrackFormatId>
   audioTrackFormatLookupTable();
@@ -68,7 +68,7 @@ namespace adm {
    * @return Map with the speaker label specified in ITU-R BS.2051 as key and
    * a vector of the corresponding speaker labels as value.
    */
-  const std::map<std::string, std::vector<std::string>>
+  ADM_EXPORT const std::map<std::string, std::vector<std::string>>
   speakerLabelsLookupTable();
 
   /**
@@ -77,9 +77,9 @@ namespace adm {
    * @param order
    * @param degree
    * @param normalization
-   * @return The corresponding AudioTrackFormat as specified in ITU-R BS.2094
+   * @return The corresponding AudioTrackFormatID as specified in ITU-R BS.2094
    */
-  ADM_EXPORT const adm::AudioTrackFormatId
-  audioTrackFormatHoaLookup(int order, int degree, std::string normalization);
+  ADM_EXPORT const adm::AudioTrackFormatId audioTrackFormatHoaLookup(
+      int order, int degree, std::string normalization);
 
 }  // namespace adm

--- a/include/adm/common_definitions.hpp
+++ b/include/adm/common_definitions.hpp
@@ -30,7 +30,7 @@ namespace adm {
    * @return Map with the loudspeaker id specified in ITU-R BS.2051 as key and
    * the corresponding AudioPackFormatId as value.
    */
-  const std::map<std::string, adm::AudioPackFormatId>
+  ADM_EXPORT const std::map<std::string, adm::AudioPackFormatId>
   audioPackFormatLookupTable();
 
   /**
@@ -48,11 +48,11 @@ namespace adm {
    * @return Map with the speaker label specified in ITU-R BS.2051 as key and
    * the corresponding AudioTrackFormat as value.
    */
-  const std::map<std::string, adm::AudioTrackFormatId>
+  ADM_EXPORT const std::map<std::string, adm::AudioTrackFormatId>
   audioTrackFormatLookupTable();
 
   /**
-   * @brief Lookup table for SpeakerLabels of loufspeaker setup
+   * @brief Lookup table for SpeakerLabels of loudspeaker setup
    *
    * Specified loudspeaker ids:
    *
@@ -70,5 +70,16 @@ namespace adm {
    */
   const std::map<std::string, std::vector<std::string>>
   speakerLabelsLookupTable();
+
+  /**
+   * @brief Lookup function for AudioTrackFormats of type HOA, using order,
+   * degree, and normalization
+   * @param order
+   * @param degree
+   * @param normalization
+   * @return The corresponding AudioTrackFormat as specified in ITU-R BS.2094
+   */
+  ADM_EXPORT const adm::AudioTrackFormatId
+  audioTrackFormatHoaLookup(int order, int degree, std::string normalization);
 
 }  // namespace adm

--- a/resources/common_definitions.xml
+++ b/resources/common_definitions.xml
@@ -260,180 +260,180 @@
           <audioChannelFormatIDRef>AC_00040004</audioChannelFormatIDRef>
         </audioPackFormat>
         <audioPackFormat audioPackFormatID="AP_00040002" audioPackFormatName="3D_order2_SN3D_ACN" typeLabel="0004" typeDefinition="HOA">
-          <audioChannelFormatIDRef>AC_00040001</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040002</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040003</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040004</audioChannelFormatIDRef>
           <audioChannelFormatIDRef>AC_00040005</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040006</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040007</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040008</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040009</audioChannelFormatIDRef>
           <audioPackFormatIDRef>AP_00040001</audioPackFormatIDRef>
         </audioPackFormat>
         <audioPackFormat audioPackFormatID="AP_00040003" audioPackFormatName="3D_order3_SN3D_ACN" typeLabel="0004" typeDefinition="HOA">
-          <audioChannelFormatIDRef>AC_00040001</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040002</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040003</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040004</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040005</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040006</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040007</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004000a</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004000b</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004000c</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004000d</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004000e</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004000f</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040010</audioChannelFormatIDRef>
           <audioPackFormatIDRef>AP_00040002</audioPackFormatIDRef>
         </audioPackFormat>
         <audioPackFormat audioPackFormatID="AP_00040004" audioPackFormatName="3D_order4_SN3D_ACN" typeLabel="0004" typeDefinition="HOA">
-          <audioChannelFormatIDRef>AC_00040001</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040002</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040003</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040004</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040005</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040006</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040007</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040008</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040009</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040011</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040012</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040013</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040014</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040015</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040016</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040017</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040018</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040019</audioChannelFormatIDRef>
           <audioPackFormatIDRef>AP_00040003</audioPackFormatIDRef>
         </audioPackFormat>
         <audioPackFormat audioPackFormatID="AP_00040005" audioPackFormatName="3D_order5_SN3D_ACN" typeLabel="0004" typeDefinition="HOA">
-          <audioChannelFormatIDRef>AC_00040001</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040002</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040003</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040004</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040005</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040006</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040007</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040008</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040009</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_0004000a</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_0004000b</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004001a</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004001b</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004001c</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004001d</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004001e</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004001f</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040020</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040021</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040022</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040023</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040024</audioChannelFormatIDRef>
           <audioPackFormatIDRef>AP_00040004</audioPackFormatIDRef>
         </audioPackFormat>
         <audioPackFormat audioPackFormatID="AP_00040006" audioPackFormatName="3D_order6_SN3D_ACN" typeLabel="0004" typeDefinition="HOA">
-          <audioChannelFormatIDRef>AC_00040001</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040002</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040003</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040004</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040005</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040006</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040007</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040008</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040009</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_0004000a</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_0004000b</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_0004000c</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_0004000d</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040025</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040026</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040027</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040028</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040029</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004002a</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004002b</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004002c</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004002d</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004002e</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004002f</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040030</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040031</audioChannelFormatIDRef>
           <audioPackFormatIDRef>AP_00040005</audioPackFormatIDRef>
         </audioPackFormat>
         <audioPackFormat audioPackFormatID="AP_00040011" audioPackFormatName="3D_order1_N3D_ACN" typeLabel="0004" typeDefinition="HOA">
-          <audioChannelFormatIDRef>AC_00040001</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040002</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040003</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040004</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040101</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040102</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040103</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040104</audioChannelFormatIDRef>
         </audioPackFormat>
         <audioPackFormat audioPackFormatID="AP_00040012" audioPackFormatName="3D_order2_N3D_ACN" typeLabel="0004" typeDefinition="HOA">
-          <audioChannelFormatIDRef>AC_00040001</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040002</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040003</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040004</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040005</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040105</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040106</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040107</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040108</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040109</audioChannelFormatIDRef>
           <audioPackFormatIDRef>AP_00040011</audioPackFormatIDRef>
         </audioPackFormat>
         <audioPackFormat audioPackFormatID="AP_00040013" audioPackFormatName="3D_order3_N3D_ACN" typeLabel="0004" typeDefinition="HOA">
-          <audioChannelFormatIDRef>AC_00040001</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040002</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040003</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040004</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040005</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040006</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040007</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004010a</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004010b</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004010c</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004010d</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004010e</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004010f</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040110</audioChannelFormatIDRef>
           <audioPackFormatIDRef>AP_00040012</audioPackFormatIDRef>
         </audioPackFormat>
         <audioPackFormat audioPackFormatID="AP_00040014" audioPackFormatName="3D_order4_N3D_ACN" typeLabel="0004" typeDefinition="HOA">
-          <audioChannelFormatIDRef>AC_00040001</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040002</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040003</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040004</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040005</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040006</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040007</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040008</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040009</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040111</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040112</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040113</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040114</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040115</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040116</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040117</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040118</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040119</audioChannelFormatIDRef>
           <audioPackFormatIDRef>AP_00040013</audioPackFormatIDRef>
         </audioPackFormat>
         <audioPackFormat audioPackFormatID="AP_00040015" audioPackFormatName="3D_order5_N3D_ACN" typeLabel="0004" typeDefinition="HOA">
-          <audioChannelFormatIDRef>AC_00040001</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040002</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040003</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040004</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040005</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040006</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040007</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040008</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040009</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_0004000a</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_0004000b</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004011a</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004011b</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004011c</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004011d</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004011e</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004011f</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040120</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040121</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040122</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040123</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040124</audioChannelFormatIDRef>
           <audioPackFormatIDRef>AP_00040014</audioPackFormatIDRef>
         </audioPackFormat>
         <audioPackFormat audioPackFormatID="AP_00040016" audioPackFormatName="3D_order6_N3D_ACN" typeLabel="0004" typeDefinition="HOA">
-          <audioChannelFormatIDRef>AC_00040001</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040002</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040003</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040004</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040005</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040006</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040007</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040008</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040009</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_0004000a</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_0004000b</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_0004000c</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_0004000d</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040125</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040126</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040127</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040128</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040129</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004012a</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004012b</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004012c</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004012d</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004012e</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004012f</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040130</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040131</audioChannelFormatIDRef>
           <audioPackFormatIDRef>AP_00040015</audioPackFormatIDRef>
         </audioPackFormat>
         <audioPackFormat audioPackFormatID="AP_00040021" audioPackFormatName="3D_order1_FuMa" typeLabel="0004" typeDefinition="HOA">
-          <audioChannelFormatIDRef>AC_00040001</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040002</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040003</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040004</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040201</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040202</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040203</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040204</audioChannelFormatIDRef>
         </audioPackFormat>
         <audioPackFormat audioPackFormatID="AP_00040022" audioPackFormatName="3D_order2_FuMa" typeLabel="0004" typeDefinition="HOA">
-          <audioChannelFormatIDRef>AC_00040001</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040002</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040003</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040004</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040005</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040205</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040206</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040207</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040208</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040209</audioChannelFormatIDRef>
           <audioPackFormatIDRef>AP_00040021</audioPackFormatIDRef>
         </audioPackFormat>
         <audioPackFormat audioPackFormatID="AP_00040023" audioPackFormatName="3D_order3_FuMa" typeLabel="0004" typeDefinition="HOA">
-          <audioChannelFormatIDRef>AC_00040001</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040002</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040003</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040004</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040005</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040006</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040007</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004020a</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004020b</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004020c</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004020d</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004020e</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004020f</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040210</audioChannelFormatIDRef>
           <audioPackFormatIDRef>AP_00040022</audioPackFormatIDRef>
         </audioPackFormat>
         <audioPackFormat audioPackFormatID="AP_00040111" audioPackFormatName="2D_Order1_N3D_ACN" typeLabel="0004" typeDefinition="HOA">
-          <audioChannelFormatIDRef>AC_00040001</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040002</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040003</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040101</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040102</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040104</audioChannelFormatIDRef>
         </audioPackFormat>
         <audioPackFormat audioPackFormatID="AP_00040112" audioPackFormatName="2D_Order2_N3D_ACN" typeLabel="0004" typeDefinition="HOA">
-          <audioChannelFormatIDRef>AC_00040001</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040002</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040105</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040109</audioChannelFormatIDRef>
           <audioPackFormatIDRef>AP_00040111</audioPackFormatIDRef>
         </audioPackFormat>
         <audioPackFormat audioPackFormatID="AP_00040210" audioPackFormatName="2H1P_N3D_ACN" typeLabel="0004" typeDefinition="HOA">
-          <audioChannelFormatIDRef>AC_00040001</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040002</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040105</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040109</audioChannelFormatIDRef>
           <audioPackFormatIDRef>AP_00040011</audioPackFormatIDRef>
         </audioPackFormat>
         <audioPackFormat audioPackFormatID="AP_00040211" audioPackFormatName="3H1P_N3D_ACN" typeLabel="0004" typeDefinition="HOA">
-          <audioChannelFormatIDRef>AC_00040001</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040002</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0004010a</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040110</audioChannelFormatIDRef>
           <audioPackFormatIDRef>AP_00040210</audioPackFormatIDRef>
         </audioPackFormat>
         <audioPackFormat audioPackFormatID="AP_00040310" audioPackFormatName="2H1V_N3D_ACN" typeLabel="0004" typeDefinition="HOA">
-          <audioChannelFormatIDRef>AC_00040001</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040002</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040003</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_00040004</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040105</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040106</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040108</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_00040109</audioChannelFormatIDRef>
           <audioPackFormatIDRef>AP_00040011</audioPackFormatIDRef>
         </audioPackFormat>
         <audioChannelFormat audioChannelFormatID="AC_00010001" audioChannelFormatName="FrontLeft" typeLabel="0001" typeDefinition="DirectSpeakers">
@@ -488,7 +488,7 @@
         <audioChannelFormat audioChannelFormatID="AC_00010007" audioChannelFormatName="FrontLeftOfCentre" typeLabel="0001" typeDefinition="DirectSpeakers">
           <audioBlockFormat audioBlockFormatID="AB_00010007_00000001">
             <speakerLabel>urn:itu:bs:2051:0:speaker:M+022</speakerLabel>
-            <position coordinate="azimuth">22.0</position>
+            <position coordinate="azimuth">22.5</position>
             <position coordinate="elevation">0.0</position>
             <position coordinate="distance">1.0</position>
           </audioBlockFormat>
@@ -496,7 +496,7 @@
         <audioChannelFormat audioChannelFormatID="AC_00010008" audioChannelFormatName="FrontRightOfCentre" typeLabel="0001" typeDefinition="DirectSpeakers">
           <audioBlockFormat audioBlockFormatID="AB_00010008_00000001">
             <speakerLabel>urn:itu:bs:2051:0:speaker:M-022</speakerLabel>
-            <position coordinate="azimuth">-22.0</position>
+            <position coordinate="azimuth">-22.5</position>
             <position coordinate="elevation">0.0</position>
             <position coordinate="distance">1.0</position>
           </audioBlockFormat>
@@ -769,1806 +769,1806 @@
           <audioBlockFormat audioBlockFormatID="AB_00040001_00000001">
             <degree>0</degree>
             <order>0</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040002" audioChannelFormatName="SN3D_ACN_1" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040002_00000001">
             <degree>-1</degree>
             <order>1</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040003" audioChannelFormatName="SN3D_ACN_2" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040003_00000001">
             <degree>0</degree>
             <order>1</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040004" audioChannelFormatName="SN3D_ACN_3" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040004_00000001">
             <degree>1</degree>
             <order>1</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040005" audioChannelFormatName="SN3D_ACN_4" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040005_00000001">
             <degree>-2</degree>
             <order>2</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040006" audioChannelFormatName="SN3D_ACN_5" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040006_00000001">
             <degree>-1</degree>
             <order>2</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040007" audioChannelFormatName="SN3D_ACN_6" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040007_00000001">
             <degree>0</degree>
             <order>2</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040008" audioChannelFormatName="SN3D_ACN_7" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040008_00000001">
             <degree>1</degree>
             <order>2</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040009" audioChannelFormatName="SN3D_ACN_8" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040009_00000001">
             <degree>2</degree>
             <order>2</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004000a" audioChannelFormatName="SN3D_ACN_9" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004000a_00000001">
             <degree>-3</degree>
             <order>3</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004000b" audioChannelFormatName="SN3D_ACN_10" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004000b_00000001">
             <degree>-2</degree>
             <order>3</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004000c" audioChannelFormatName="SN3D_ACN_11" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004000c_00000001">
             <degree>-1</degree>
             <order>3</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004000d" audioChannelFormatName="SN3D_ACN_12" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004000d_00000001">
             <degree>0</degree>
             <order>3</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004000e" audioChannelFormatName="SN3D_ACN_13" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004000e_00000001">
             <degree>1</degree>
             <order>3</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004000f" audioChannelFormatName="SN3D_ACN_14" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004000f_00000001">
             <degree>2</degree>
             <order>3</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040010" audioChannelFormatName="SN3D_ACN_15" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040010_00000001">
             <degree>3</degree>
             <order>3</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040011" audioChannelFormatName="SN3D_ACN_16" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040011_00000001">
             <degree>-4</degree>
             <order>4</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040012" audioChannelFormatName="SN3D_ACN_17" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040012_00000001">
             <degree>-3</degree>
             <order>4</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040013" audioChannelFormatName="SN3D_ACN_18" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040013_00000001">
             <degree>-2</degree>
             <order>4</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040014" audioChannelFormatName="SN3D_ACN_19" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040014_00000001">
             <degree>-1</degree>
             <order>4</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040015" audioChannelFormatName="SN3D_ACN_20" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040015_00000001">
             <degree>0</degree>
             <order>4</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040016" audioChannelFormatName="SN3D_ACN_21" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040016_00000001">
             <degree>1</degree>
             <order>4</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040017" audioChannelFormatName="SN3D_ACN_22" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040017_00000001">
             <degree>2</degree>
             <order>4</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040018" audioChannelFormatName="SN3D_ACN_23" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040018_00000001">
             <degree>3</degree>
             <order>4</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040019" audioChannelFormatName="SN3D_ACN_24" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040019_00000001">
             <degree>4</degree>
             <order>4</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004001a" audioChannelFormatName="SN3D_ACN_25" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004001a_00000001">
             <degree>-5</degree>
             <order>5</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004001b" audioChannelFormatName="SN3D_ACN_26" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004001b_00000001">
             <degree>-4</degree>
             <order>5</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004001c" audioChannelFormatName="SN3D_ACN_27" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004001c_00000001">
             <degree>-3</degree>
             <order>5</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004001d" audioChannelFormatName="SN3D_ACN_28" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004001d_00000001">
             <degree>-2</degree>
             <order>5</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004001e" audioChannelFormatName="SN3D_ACN_29" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004001e_00000001">
             <degree>-1</degree>
             <order>5</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004001f" audioChannelFormatName="SN3D_ACN_30" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004001f_00000001">
             <degree>0</degree>
             <order>5</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040020" audioChannelFormatName="SN3D_ACN_31" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040020_00000001">
             <degree>1</degree>
             <order>5</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040021" audioChannelFormatName="SN3D_ACN_32" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040021_00000001">
             <degree>2</degree>
             <order>5</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040022" audioChannelFormatName="SN3D_ACN_33" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040022_00000001">
             <degree>3</degree>
             <order>5</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040023" audioChannelFormatName="SN3D_ACN_34" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040023_00000001">
             <degree>4</degree>
             <order>5</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040024" audioChannelFormatName="SN3D_ACN_35" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040024_00000001">
             <degree>5</degree>
             <order>5</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040025" audioChannelFormatName="SN3D_ACN_36" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040025_00000001">
             <degree>-6</degree>
             <order>6</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040026" audioChannelFormatName="SN3D_ACN_37" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040026_00000001">
             <degree>-5</degree>
             <order>6</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040027" audioChannelFormatName="SN3D_ACN_38" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040027_00000001">
             <degree>-4</degree>
             <order>6</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040028" audioChannelFormatName="SN3D_ACN_39" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040028_00000001">
             <degree>-3</degree>
             <order>6</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040029" audioChannelFormatName="SN3D_ACN_40" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040029_00000001">
             <degree>-2</degree>
             <order>6</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004002a" audioChannelFormatName="SN3D_ACN_41" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004002a_00000001">
             <degree>-1</degree>
             <order>6</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004002b" audioChannelFormatName="SN3D_ACN_42" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004002b_00000001">
             <degree>0</degree>
             <order>6</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004002c" audioChannelFormatName="SN3D_ACN_43" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004002c_00000001">
             <degree>1</degree>
             <order>6</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004002d" audioChannelFormatName="SN3D_ACN_44" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004002d_00000001">
             <degree>2</degree>
             <order>6</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004002e" audioChannelFormatName="SN3D_ACN_45" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004002e_00000001">
             <degree>3</degree>
             <order>6</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004002f" audioChannelFormatName="SN3D_ACN_46" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004002f_00000001">
             <degree>4</degree>
             <order>6</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040030" audioChannelFormatName="SN3D_ACN_47" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040030_00000001">
             <degree>5</degree>
             <order>6</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040031" audioChannelFormatName="SN3D_ACN_48" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040031_00000001">
             <degree>6</degree>
             <order>6</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040032" audioChannelFormatName="SN3D_ACN_49" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040032_00000001">
             <degree>-7</degree>
             <order>7</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040033" audioChannelFormatName="SN3D_ACN_50" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040033_00000001">
             <degree>-6</degree>
             <order>7</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040034" audioChannelFormatName="SN3D_ACN_51" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040034_00000001">
             <degree>-5</degree>
             <order>7</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040035" audioChannelFormatName="SN3D_ACN_52" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040035_00000001">
             <degree>-4</degree>
             <order>7</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040036" audioChannelFormatName="SN3D_ACN_53" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040036_00000001">
             <degree>-3</degree>
             <order>7</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040037" audioChannelFormatName="SN3D_ACN_54" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040037_00000001">
             <degree>-2</degree>
             <order>7</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040038" audioChannelFormatName="SN3D_ACN_55" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040038_00000001">
             <degree>-1</degree>
             <order>7</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040039" audioChannelFormatName="SN3D_ACN_56" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040039_00000001">
             <degree>0</degree>
             <order>7</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004003a" audioChannelFormatName="SN3D_ACN_57" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004003a_00000001">
             <degree>1</degree>
             <order>7</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004003b" audioChannelFormatName="SN3D_ACN_58" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004003b_00000001">
             <degree>2</degree>
             <order>7</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004003c" audioChannelFormatName="SN3D_ACN_59" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004003c_00000001">
             <degree>3</degree>
             <order>7</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004003d" audioChannelFormatName="SN3D_ACN_60" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004003d_00000001">
             <degree>4</degree>
             <order>7</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004003e" audioChannelFormatName="SN3D_ACN_61" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004003e_00000001">
             <degree>5</degree>
             <order>7</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004003f" audioChannelFormatName="SN3D_ACN_62" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004003f_00000001">
             <degree>6</degree>
             <order>7</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040040" audioChannelFormatName="SN3D_ACN_63" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040040_00000001">
             <degree>7</degree>
             <order>7</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040041" audioChannelFormatName="SN3D_ACN_64" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040041_00000001">
             <degree>-8</degree>
             <order>8</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040042" audioChannelFormatName="SN3D_ACN_65" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040042_00000001">
             <degree>-7</degree>
             <order>8</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040043" audioChannelFormatName="SN3D_ACN_66" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040043_00000001">
             <degree>-6</degree>
             <order>8</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040044" audioChannelFormatName="SN3D_ACN_67" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040044_00000001">
             <degree>-5</degree>
             <order>8</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040045" audioChannelFormatName="SN3D_ACN_68" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040045_00000001">
             <degree>-4</degree>
             <order>8</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040046" audioChannelFormatName="SN3D_ACN_69" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040046_00000001">
             <degree>-3</degree>
             <order>8</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040047" audioChannelFormatName="SN3D_ACN_70" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040047_00000001">
             <degree>-2</degree>
             <order>8</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040048" audioChannelFormatName="SN3D_ACN_71" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040048_00000001">
             <degree>-1</degree>
             <order>8</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040049" audioChannelFormatName="SN3D_ACN_72" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040049_00000001">
             <degree>0</degree>
             <order>8</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004004a" audioChannelFormatName="SN3D_ACN_73" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004004a_00000001">
             <degree>1</degree>
             <order>8</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004004b" audioChannelFormatName="SN3D_ACN_74" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004004b_00000001">
             <degree>2</degree>
             <order>8</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004004c" audioChannelFormatName="SN3D_ACN_75" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004004c_00000001">
             <degree>3</degree>
             <order>8</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004004d" audioChannelFormatName="SN3D_ACN_76" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004004d_00000001">
             <degree>4</degree>
             <order>8</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004004e" audioChannelFormatName="SN3D_ACN_77" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004004e_00000001">
             <degree>5</degree>
             <order>8</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004004f" audioChannelFormatName="SN3D_ACN_78" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004004f_00000001">
             <degree>6</degree>
             <order>8</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040050" audioChannelFormatName="SN3D_ACN_79" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040050_00000001">
             <degree>7</degree>
             <order>8</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040051" audioChannelFormatName="SN3D_ACN_80" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040051_00000001">
             <degree>8</degree>
             <order>8</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040052" audioChannelFormatName="SN3D_ACN_81" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040052_00000001">
             <degree>-9</degree>
             <order>9</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040053" audioChannelFormatName="SN3D_ACN_82" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040053_00000001">
             <degree>-8</degree>
             <order>9</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040054" audioChannelFormatName="SN3D_ACN_83" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040054_00000001">
             <degree>-7</degree>
             <order>9</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040055" audioChannelFormatName="SN3D_ACN_84" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040055_00000001">
             <degree>-6</degree>
             <order>9</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040056" audioChannelFormatName="SN3D_ACN_85" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040056_00000001">
             <degree>-5</degree>
             <order>9</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040057" audioChannelFormatName="SN3D_ACN_86" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040057_00000001">
             <degree>-4</degree>
             <order>9</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040058" audioChannelFormatName="SN3D_ACN_87" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040058_00000001">
             <degree>-3</degree>
             <order>9</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040059" audioChannelFormatName="SN3D_ACN_88" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040059_00000001">
             <degree>-2</degree>
             <order>9</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004005a" audioChannelFormatName="SN3D_ACN_89" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004005a_00000001">
             <degree>-1</degree>
             <order>9</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004005b" audioChannelFormatName="SN3D_ACN_90" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004005b_00000001">
             <degree>0</degree>
             <order>9</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004005c" audioChannelFormatName="SN3D_ACN_91" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004005c_00000001">
             <degree>1</degree>
             <order>9</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004005d" audioChannelFormatName="SN3D_ACN_92" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004005d_00000001">
             <degree>2</degree>
             <order>9</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004005e" audioChannelFormatName="SN3D_ACN_93" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004005e_00000001">
             <degree>3</degree>
             <order>9</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004005f" audioChannelFormatName="SN3D_ACN_94" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004005f_00000001">
             <degree>4</degree>
             <order>9</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040060" audioChannelFormatName="SN3D_ACN_95" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040060_00000001">
             <degree>5</degree>
             <order>9</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040061" audioChannelFormatName="SN3D_ACN_96" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040061_00000001">
             <degree>6</degree>
             <order>9</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040062" audioChannelFormatName="SN3D_ACN_97" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040062_00000001">
             <degree>7</degree>
             <order>9</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040063" audioChannelFormatName="SN3D_ACN_98" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040063_00000001">
             <degree>8</degree>
             <order>9</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040064" audioChannelFormatName="SN3D_ACN_99" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040064_00000001">
             <degree>9</degree>
             <order>9</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040065" audioChannelFormatName="SN3D_ACN_100" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040065_00000001">
             <degree>-10</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040066" audioChannelFormatName="SN3D_ACN_101" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040066_00000001">
             <degree>-9</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040067" audioChannelFormatName="SN3D_ACN_102" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040067_00000001">
             <degree>-8</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040068" audioChannelFormatName="SN3D_ACN_103" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040068_00000001">
             <degree>-7</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040069" audioChannelFormatName="SN3D_ACN_104" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040069_00000001">
             <degree>-6</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004006a" audioChannelFormatName="SN3D_ACN_105" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004006a_00000001">
             <degree>-5</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004006b" audioChannelFormatName="SN3D_ACN_106" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004006b_00000001">
             <degree>-4</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004006c" audioChannelFormatName="SN3D_ACN_107" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004006c_00000001">
             <degree>-3</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004006d" audioChannelFormatName="SN3D_ACN_108" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004006d_00000001">
             <degree>-2</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004006e" audioChannelFormatName="SN3D_ACN_109" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004006e_00000001">
             <degree>-1</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004006f" audioChannelFormatName="SN3D_ACN_110" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004006f_00000001">
             <degree>0</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040070" audioChannelFormatName="SN3D_ACN_111" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040070_00000001">
             <degree>1</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040071" audioChannelFormatName="SN3D_ACN_112" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040071_00000001">
             <degree>2</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040072" audioChannelFormatName="SN3D_ACN_113" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040072_00000001">
             <degree>3</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040073" audioChannelFormatName="SN3D_ACN_114" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040073_00000001">
             <degree>4</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040074" audioChannelFormatName="SN3D_ACN_115" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040074_00000001">
             <degree>5</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040075" audioChannelFormatName="SN3D_ACN_116" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040075_00000001">
             <degree>6</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040076" audioChannelFormatName="SN3D_ACN_117" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040076_00000001">
             <degree>7</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040077" audioChannelFormatName="SN3D_ACN_118" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040077_00000001">
             <degree>8</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040078" audioChannelFormatName="SN3D_ACN_119" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040078_00000001">
             <degree>9</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040079" audioChannelFormatName="SN3D_ACN_120" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040079_00000001">
             <degree>10</degree>
             <order>10</order>
-            <normalisation>SN3D</normalisation>
+            <normalization>SN3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040101" audioChannelFormatName="N3D_ACN_0" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040101_00000001">
             <degree>0</degree>
             <order>0</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040102" audioChannelFormatName="N3D_ACN_1" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040102_00000001">
             <degree>-1</degree>
             <order>1</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040103" audioChannelFormatName="N3D_ACN_2" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040103_00000001">
             <degree>0</degree>
             <order>1</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040104" audioChannelFormatName="N3D_ACN_3" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040104_00000001">
             <degree>1</degree>
             <order>1</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040105" audioChannelFormatName="N3D_ACN_4" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040105_00000001">
             <degree>-2</degree>
             <order>2</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040106" audioChannelFormatName="N3D_ACN_5" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040106_00000001">
             <degree>-1</degree>
             <order>2</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040107" audioChannelFormatName="N3D_ACN_6" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040107_00000001">
             <degree>0</degree>
             <order>2</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040108" audioChannelFormatName="N3D_ACN_7" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040108_00000001">
             <degree>1</degree>
             <order>2</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040109" audioChannelFormatName="N3D_ACN_8" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040109_00000001">
             <degree>2</degree>
             <order>2</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004010a" audioChannelFormatName="N3D_ACN_9" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004010a_00000001">
             <degree>-3</degree>
             <order>3</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004010b" audioChannelFormatName="N3D_ACN_10" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004010b_00000001">
             <degree>-2</degree>
             <order>3</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004010c" audioChannelFormatName="N3D_ACN_11" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004010c_00000001">
             <degree>-1</degree>
             <order>3</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004010d" audioChannelFormatName="N3D_ACN_12" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004010d_00000001">
             <degree>0</degree>
             <order>3</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004010e" audioChannelFormatName="N3D_ACN_13" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004010e_00000001">
             <degree>1</degree>
             <order>3</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004010f" audioChannelFormatName="N3D_ACN_14" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004010f_00000001">
             <degree>2</degree>
             <order>3</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040110" audioChannelFormatName="N3D_ACN_15" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040110_00000001">
             <degree>3</degree>
             <order>3</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040111" audioChannelFormatName="N3D_ACN_16" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040111_00000001">
             <degree>-4</degree>
             <order>4</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040112" audioChannelFormatName="N3D_ACN_17" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040112_00000001">
             <degree>-3</degree>
             <order>4</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040113" audioChannelFormatName="N3D_ACN_18" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040113_00000001">
             <degree>-2</degree>
             <order>4</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040114" audioChannelFormatName="N3D_ACN_19" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040114_00000001">
             <degree>-1</degree>
             <order>4</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040115" audioChannelFormatName="N3D_ACN_20" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040115_00000001">
             <degree>0</degree>
             <order>4</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040116" audioChannelFormatName="N3D_ACN_21" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040116_00000001">
             <degree>1</degree>
             <order>4</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040117" audioChannelFormatName="N3D_ACN_22" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040117_00000001">
             <degree>2</degree>
             <order>4</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040118" audioChannelFormatName="N3D_ACN_23" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040118_00000001">
             <degree>3</degree>
             <order>4</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040119" audioChannelFormatName="N3D_ACN_24" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040119_00000001">
             <degree>4</degree>
             <order>4</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004011a" audioChannelFormatName="N3D_ACN_25" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004011a_00000001">
             <degree>-5</degree>
             <order>5</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004011b" audioChannelFormatName="N3D_ACN_26" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004011b_00000001">
             <degree>-4</degree>
             <order>5</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004011c" audioChannelFormatName="N3D_ACN_27" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004011c_00000001">
             <degree>-3</degree>
             <order>5</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004011d" audioChannelFormatName="N3D_ACN_28" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004011d_00000001">
             <degree>-2</degree>
             <order>5</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004011e" audioChannelFormatName="N3D_ACN_29" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004011e_00000001">
             <degree>-1</degree>
             <order>5</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004011f" audioChannelFormatName="N3D_ACN_30" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004011f_00000001">
             <degree>0</degree>
             <order>5</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040120" audioChannelFormatName="N3D_ACN_31" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040120_00000001">
             <degree>1</degree>
             <order>5</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040121" audioChannelFormatName="N3D_ACN_32" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040121_00000001">
             <degree>2</degree>
             <order>5</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040122" audioChannelFormatName="N3D_ACN_33" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040122_00000001">
             <degree>3</degree>
             <order>5</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040123" audioChannelFormatName="N3D_ACN_34" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040123_00000001">
             <degree>4</degree>
             <order>5</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040124" audioChannelFormatName="N3D_ACN_35" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040124_00000001">
             <degree>5</degree>
             <order>5</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040125" audioChannelFormatName="N3D_ACN_36" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040125_00000001">
             <degree>-6</degree>
             <order>6</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040126" audioChannelFormatName="N3D_ACN_37" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040126_00000001">
             <degree>-5</degree>
             <order>6</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040127" audioChannelFormatName="N3D_ACN_38" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040127_00000001">
             <degree>-4</degree>
             <order>6</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040128" audioChannelFormatName="N3D_ACN_39" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040128_00000001">
             <degree>-3</degree>
             <order>6</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040129" audioChannelFormatName="N3D_ACN_40" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040129_00000001">
             <degree>-2</degree>
             <order>6</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004012a" audioChannelFormatName="N3D_ACN_41" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004012a_00000001">
             <degree>-1</degree>
             <order>6</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004012b" audioChannelFormatName="N3D_ACN_42" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004012b_00000001">
             <degree>0</degree>
             <order>6</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004012c" audioChannelFormatName="N3D_ACN_43" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004012c_00000001">
             <degree>1</degree>
             <order>6</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004012d" audioChannelFormatName="N3D_ACN_44" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004012d_00000001">
             <degree>2</degree>
             <order>6</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004012e" audioChannelFormatName="N3D_ACN_45" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004012e_00000001">
             <degree>3</degree>
             <order>6</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004012f" audioChannelFormatName="N3D_ACN_46" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004012f_00000001">
             <degree>4</degree>
             <order>6</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040130" audioChannelFormatName="N3D_ACN_47" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040130_00000001">
             <degree>5</degree>
             <order>6</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040131" audioChannelFormatName="N3D_ACN_48" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040131_00000001">
             <degree>6</degree>
             <order>6</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040132" audioChannelFormatName="N3D_ACN_49" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040132_00000001">
             <degree>-7</degree>
             <order>7</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040133" audioChannelFormatName="N3D_ACN_50" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040133_00000001">
             <degree>-6</degree>
             <order>7</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040134" audioChannelFormatName="N3D_ACN_51" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040134_00000001">
             <degree>-5</degree>
             <order>7</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040135" audioChannelFormatName="N3D_ACN_52" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040135_00000001">
             <degree>-4</degree>
             <order>7</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040136" audioChannelFormatName="N3D_ACN_53" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040136_00000001">
             <degree>-3</degree>
             <order>7</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040137" audioChannelFormatName="N3D_ACN_54" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040137_00000001">
             <degree>-2</degree>
             <order>7</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040138" audioChannelFormatName="N3D_ACN_55" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040138_00000001">
             <degree>-1</degree>
             <order>7</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040139" audioChannelFormatName="N3D_ACN_56" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040139_00000001">
             <degree>0</degree>
             <order>7</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004013a" audioChannelFormatName="N3D_ACN_57" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004013a_00000001">
             <degree>1</degree>
             <order>7</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004013b" audioChannelFormatName="N3D_ACN_58" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004013b_00000001">
             <degree>2</degree>
             <order>7</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004013c" audioChannelFormatName="N3D_ACN_59" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004013c_00000001">
             <degree>3</degree>
             <order>7</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004013d" audioChannelFormatName="N3D_ACN_60" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004013d_00000001">
             <degree>4</degree>
             <order>7</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004013e" audioChannelFormatName="N3D_ACN_61" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004013e_00000001">
             <degree>5</degree>
             <order>7</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004013f" audioChannelFormatName="N3D_ACN_62" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004013f_00000001">
             <degree>6</degree>
             <order>7</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040140" audioChannelFormatName="N3D_ACN_63" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040140_00000001">
             <degree>7</degree>
             <order>7</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040141" audioChannelFormatName="N3D_ACN_64" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040141_00000001">
             <degree>-8</degree>
             <order>8</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040142" audioChannelFormatName="N3D_ACN_65" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040142_00000001">
             <degree>-7</degree>
             <order>8</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040143" audioChannelFormatName="N3D_ACN_66" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040143_00000001">
             <degree>-6</degree>
             <order>8</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040144" audioChannelFormatName="N3D_ACN_67" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040144_00000001">
             <degree>-5</degree>
             <order>8</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040145" audioChannelFormatName="N3D_ACN_68" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040145_00000001">
             <degree>-4</degree>
             <order>8</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040146" audioChannelFormatName="N3D_ACN_69" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040146_00000001">
             <degree>-3</degree>
             <order>8</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040147" audioChannelFormatName="N3D_ACN_70" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040147_00000001">
             <degree>-2</degree>
             <order>8</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040148" audioChannelFormatName="N3D_ACN_71" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040148_00000001">
             <degree>-1</degree>
             <order>8</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040149" audioChannelFormatName="N3D_ACN_72" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040149_00000001">
             <degree>0</degree>
             <order>8</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004014a" audioChannelFormatName="N3D_ACN_73" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004014a_00000001">
             <degree>1</degree>
             <order>8</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004014b" audioChannelFormatName="N3D_ACN_74" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004014b_00000001">
             <degree>2</degree>
             <order>8</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004014c" audioChannelFormatName="N3D_ACN_75" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004014c_00000001">
             <degree>3</degree>
             <order>8</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004014d" audioChannelFormatName="N3D_ACN_76" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004014d_00000001">
             <degree>4</degree>
             <order>8</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004014e" audioChannelFormatName="N3D_ACN_77" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004014e_00000001">
             <degree>5</degree>
             <order>8</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004014f" audioChannelFormatName="N3D_ACN_78" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004014f_00000001">
             <degree>6</degree>
             <order>8</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040150" audioChannelFormatName="N3D_ACN_79" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040150_00000001">
             <degree>7</degree>
             <order>8</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040151" audioChannelFormatName="N3D_ACN_80" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040151_00000001">
             <degree>8</degree>
             <order>8</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040152" audioChannelFormatName="N3D_ACN_81" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040152_00000001">
             <degree>-9</degree>
             <order>9</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040153" audioChannelFormatName="N3D_ACN_82" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040153_00000001">
             <degree>-8</degree>
             <order>9</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040154" audioChannelFormatName="N3D_ACN_83" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040154_00000001">
             <degree>-7</degree>
             <order>9</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040155" audioChannelFormatName="N3D_ACN_84" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040155_00000001">
             <degree>-6</degree>
             <order>9</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040156" audioChannelFormatName="N3D_ACN_85" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040156_00000001">
             <degree>-5</degree>
             <order>9</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040157" audioChannelFormatName="N3D_ACN_86" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040157_00000001">
             <degree>-4</degree>
             <order>9</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040158" audioChannelFormatName="N3D_ACN_87" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040158_00000001">
             <degree>-3</degree>
             <order>9</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040159" audioChannelFormatName="N3D_ACN_88" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040159_00000001">
             <degree>-2</degree>
             <order>9</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004015a" audioChannelFormatName="N3D_ACN_89" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004015a_00000001">
             <degree>-1</degree>
             <order>9</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004015b" audioChannelFormatName="N3D_ACN_90" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004015b_00000001">
             <degree>0</degree>
             <order>9</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004015c" audioChannelFormatName="N3D_ACN_91" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004015c_00000001">
             <degree>1</degree>
             <order>9</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004015d" audioChannelFormatName="N3D_ACN_92" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004015d_00000001">
             <degree>2</degree>
             <order>9</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004015e" audioChannelFormatName="N3D_ACN_93" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004015e_00000001">
             <degree>3</degree>
             <order>9</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004015f" audioChannelFormatName="N3D_ACN_94" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004015f_00000001">
             <degree>4</degree>
             <order>9</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040160" audioChannelFormatName="N3D_ACN_95" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040160_00000001">
             <degree>5</degree>
             <order>9</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040161" audioChannelFormatName="N3D_ACN_96" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040161_00000001">
             <degree>6</degree>
             <order>9</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040162" audioChannelFormatName="N3D_ACN_97" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040162_00000001">
             <degree>7</degree>
             <order>9</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040163" audioChannelFormatName="N3D_ACN_98" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040163_00000001">
             <degree>8</degree>
             <order>9</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040164" audioChannelFormatName="N3D_ACN_99" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040164_00000001">
             <degree>9</degree>
             <order>9</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040165" audioChannelFormatName="N3D_ACN_100" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040165_00000001">
             <degree>-10</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040166" audioChannelFormatName="N3D_ACN_101" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040166_00000001">
             <degree>-9</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040167" audioChannelFormatName="N3D_ACN_102" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040167_00000001">
             <degree>-8</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040168" audioChannelFormatName="N3D_ACN_103" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040168_00000001">
             <degree>-7</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040169" audioChannelFormatName="N3D_ACN_104" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040169_00000001">
             <degree>-6</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004016a" audioChannelFormatName="N3D_ACN_105" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004016a_00000001">
             <degree>-5</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004016b" audioChannelFormatName="N3D_ACN_106" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004016b_00000001">
             <degree>-4</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004016c" audioChannelFormatName="N3D_ACN_107" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004016c_00000001">
             <degree>-3</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004016d" audioChannelFormatName="N3D_ACN_108" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004016d_00000001">
             <degree>-2</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004016e" audioChannelFormatName="N3D_ACN_109" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004016e_00000001">
             <degree>-1</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004016f" audioChannelFormatName="N3D_ACN_110" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004016f_00000001">
             <degree>0</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040170" audioChannelFormatName="N3D_ACN_111" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040170_00000001">
             <degree>1</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040171" audioChannelFormatName="N3D_ACN_112" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040171_00000001">
             <degree>2</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040172" audioChannelFormatName="N3D_ACN_113" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040172_00000001">
             <degree>3</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040173" audioChannelFormatName="N3D_ACN_114" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040173_00000001">
             <degree>4</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040174" audioChannelFormatName="N3D_ACN_115" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040174_00000001">
             <degree>5</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040175" audioChannelFormatName="N3D_ACN_116" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040175_00000001">
             <degree>6</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040176" audioChannelFormatName="N3D_ACN_117" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040176_00000001">
             <degree>7</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040177" audioChannelFormatName="N3D_ACN_118" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040177_00000001">
             <degree>8</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040178" audioChannelFormatName="N3D_ACN_119" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040178_00000001">
             <degree>9</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040179" audioChannelFormatName="N3D_ACN_120" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040179_00000001">
             <degree>10</degree>
             <order>10</order>
-            <normalisation>N3D</normalisation>
+            <normalization>N3D</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_00040201" audioChannelFormatName="FuMa_W" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040201_00000001">
             <degree>0</degree>
             <order>0</order>
-            <normalisation>FuMa</normalisation>
+            <normalization>FuMa</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
-        <audioChannelFormat audioChannelFormatID="AC_00040202" audioChannelFormatName="FuMa_X" typeLabel="0004" typeDefinition="HOA">
+        <audioChannelFormat audioChannelFormatID="AC_00040202" audioChannelFormatName="FuMa_Y" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040202_00000001">
             <degree>-1</degree>
             <order>1</order>
-            <normalisation>FuMa</normalisation>
+            <normalization>FuMa</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
-        <audioChannelFormat audioChannelFormatID="AC_00040203" audioChannelFormatName="FuMa_Y" typeLabel="0004" typeDefinition="HOA">
+        <audioChannelFormat audioChannelFormatID="AC_00040203" audioChannelFormatName="FuMa_Z" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040203_00000001">
             <degree>0</degree>
             <order>1</order>
-            <normalisation>FuMa</normalisation>
+            <normalization>FuMa</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
-        <audioChannelFormat audioChannelFormatID="AC_00040204" audioChannelFormatName="FuMa_Z" typeLabel="0004" typeDefinition="HOA">
+        <audioChannelFormat audioChannelFormatID="AC_00040204" audioChannelFormatName="FuMa_X" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040204_00000001">
             <degree>1</degree>
             <order>1</order>
-            <normalisation>FuMa</normalisation>
+            <normalization>FuMa</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
-        <audioChannelFormat audioChannelFormatID="AC_00040205" audioChannelFormatName="FuMa_R" typeLabel="0004" typeDefinition="HOA">
+        <audioChannelFormat audioChannelFormatID="AC_00040205" audioChannelFormatName="FuMa_V" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040205_00000001">
             <degree>-2</degree>
             <order>2</order>
-            <normalisation>FuMa</normalisation>
+            <normalization>FuMa</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
-        <audioChannelFormat audioChannelFormatID="AC_00040206" audioChannelFormatName="FuMa_S" typeLabel="0004" typeDefinition="HOA">
+        <audioChannelFormat audioChannelFormatID="AC_00040206" audioChannelFormatName="FuMa_T" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040206_00000001">
             <degree>-1</degree>
             <order>2</order>
-            <normalisation>FuMa</normalisation>
+            <normalization>FuMa</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
-        <audioChannelFormat audioChannelFormatID="AC_00040207" audioChannelFormatName="FuMa_T" typeLabel="0004" typeDefinition="HOA">
+        <audioChannelFormat audioChannelFormatID="AC_00040207" audioChannelFormatName="FuMa_R" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040207_00000001">
             <degree>0</degree>
             <order>2</order>
-            <normalisation>FuMa</normalisation>
+            <normalization>FuMa</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
-        <audioChannelFormat audioChannelFormatID="AC_00040208" audioChannelFormatName="FuMa_U" typeLabel="0004" typeDefinition="HOA">
+        <audioChannelFormat audioChannelFormatID="AC_00040208" audioChannelFormatName="FuMa_S" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040208_00000001">
             <degree>1</degree>
             <order>2</order>
-            <normalisation>FuMa</normalisation>
+            <normalization>FuMa</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
-        <audioChannelFormat audioChannelFormatID="AC_00040209" audioChannelFormatName="FuMa_V" typeLabel="0004" typeDefinition="HOA">
+        <audioChannelFormat audioChannelFormatID="AC_00040209" audioChannelFormatName="FuMa_U" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040209_00000001">
             <degree>2</degree>
             <order>2</order>
-            <normalisation>FuMa</normalisation>
+            <normalization>FuMa</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
-        <audioChannelFormat audioChannelFormatID="AC_0004020a" audioChannelFormatName="FuMa_K" typeLabel="0004" typeDefinition="HOA">
+        <audioChannelFormat audioChannelFormatID="AC_0004020a" audioChannelFormatName="FuMa_Q" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004020a_00000001">
             <degree>-3</degree>
             <order>3</order>
-            <normalisation>FuMa</normalisation>
+            <normalization>FuMa</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
-        <audioChannelFormat audioChannelFormatID="AC_0004020b" audioChannelFormatName="FuMa_L" typeLabel="0004" typeDefinition="HOA">
+        <audioChannelFormat audioChannelFormatID="AC_0004020b" audioChannelFormatName="FuMa_O" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004020b_00000001">
             <degree>-2</degree>
             <order>3</order>
-            <normalisation>FuMa</normalisation>
+            <normalization>FuMa</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioChannelFormat audioChannelFormatID="AC_0004020c" audioChannelFormatName="FuMa_M" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004020c_00000001">
             <degree>-1</degree>
             <order>3</order>
-            <normalisation>FuMa</normalisation>
+            <normalization>FuMa</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
-        <audioChannelFormat audioChannelFormatID="AC_0004020d" audioChannelFormatName="FuMa_N" typeLabel="0004" typeDefinition="HOA">
+        <audioChannelFormat audioChannelFormatID="AC_0004020d" audioChannelFormatName="FuMa_K" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004020d_00000001">
             <degree>0</degree>
             <order>3</order>
-            <normalisation>FuMa</normalisation>
+            <normalization>FuMa</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
-        <audioChannelFormat audioChannelFormatID="AC_0004020e" audioChannelFormatName="FuMa_O" typeLabel="0004" typeDefinition="HOA">
+        <audioChannelFormat audioChannelFormatID="AC_0004020e" audioChannelFormatName="FuMa_L" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004020e_00000001">
             <degree>1</degree>
             <order>3</order>
-            <normalisation>FuMa</normalisation>
+            <normalization>FuMa</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
-        <audioChannelFormat audioChannelFormatID="AC_0004020f" audioChannelFormatName="FuMa_P" typeLabel="0004" typeDefinition="HOA">
+        <audioChannelFormat audioChannelFormatID="AC_0004020f" audioChannelFormatName="FuMa_N" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_0004020f_00000001">
             <degree>2</degree>
             <order>3</order>
-            <normalisation>FuMa</normalisation>
+            <normalization>FuMa</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
-        <audioChannelFormat audioChannelFormatID="AC_00040210" audioChannelFormatName="FuMa_Q" typeLabel="0004" typeDefinition="HOA">
+        <audioChannelFormat audioChannelFormatID="AC_00040210" audioChannelFormatName="FuMa_P" typeLabel="0004" typeDefinition="HOA">
           <audioBlockFormat audioBlockFormatID="AB_00040210_00000001">
             <degree>3</degree>
             <order>3</order>
-            <normalisation>FuMa</normalisation>
+            <normalization>FuMa</normalization>
           </audioBlockFormat>
         </audioChannelFormat>
         <audioStreamFormat audioStreamFormatID="AS_00010001" audioStreamFormatName="PCM_FrontLeft" formatLabel="0001" formatDefinition="PCM">
@@ -3711,43 +3711,43 @@
           <audioChannelFormatIDRef>AC_00040201</audioChannelFormatIDRef>
           <audioTrackFormatIDRef>AT_00040201_01</audioTrackFormatIDRef>
         </audioStreamFormat>
-        <audioStreamFormat audioStreamFormatID="AS_00040202" audioStreamFormatName="PCM_FuMa_X" formatLabel="0001" formatDefinition="PCM">
+        <audioStreamFormat audioStreamFormatID="AS_00040202" audioStreamFormatName="PCM_FuMa_Y" formatLabel="0001" formatDefinition="PCM">
           <audioChannelFormatIDRef>AC_00040202</audioChannelFormatIDRef>
           <audioTrackFormatIDRef>AT_00040202_01</audioTrackFormatIDRef>
         </audioStreamFormat>
-        <audioStreamFormat audioStreamFormatID="AS_00040203" audioStreamFormatName="PCM_FuMa_Y" formatLabel="0001" formatDefinition="PCM">
+        <audioStreamFormat audioStreamFormatID="AS_00040203" audioStreamFormatName="PCM_FuMa_Z" formatLabel="0001" formatDefinition="PCM">
           <audioChannelFormatIDRef>AC_00040203</audioChannelFormatIDRef>
           <audioTrackFormatIDRef>AT_00040203_01</audioTrackFormatIDRef>
         </audioStreamFormat>
-        <audioStreamFormat audioStreamFormatID="AS_00040204" audioStreamFormatName="PCM_FuMa_Z" formatLabel="0001" formatDefinition="PCM">
+        <audioStreamFormat audioStreamFormatID="AS_00040204" audioStreamFormatName="PCM_FuMa_X" formatLabel="0001" formatDefinition="PCM">
           <audioChannelFormatIDRef>AC_00040204</audioChannelFormatIDRef>
           <audioTrackFormatIDRef>AT_00040204_01</audioTrackFormatIDRef>
         </audioStreamFormat>
-        <audioStreamFormat audioStreamFormatID="AS_00040205" audioStreamFormatName="PCM_FuMa_R" formatLabel="0001" formatDefinition="PCM">
+        <audioStreamFormat audioStreamFormatID="AS_00040205" audioStreamFormatName="PCM_FuMa_V" formatLabel="0001" formatDefinition="PCM">
           <audioChannelFormatIDRef>AC_00040205</audioChannelFormatIDRef>
           <audioTrackFormatIDRef>AT_00040205_01</audioTrackFormatIDRef>
         </audioStreamFormat>
-        <audioStreamFormat audioStreamFormatID="AS_00040206" audioStreamFormatName="PCM_FuMa_S" formatLabel="0001" formatDefinition="PCM">
+        <audioStreamFormat audioStreamFormatID="AS_00040206" audioStreamFormatName="PCM_FuMa_T" formatLabel="0001" formatDefinition="PCM">
           <audioChannelFormatIDRef>AC_00040206</audioChannelFormatIDRef>
           <audioTrackFormatIDRef>AT_00040206_01</audioTrackFormatIDRef>
         </audioStreamFormat>
-        <audioStreamFormat audioStreamFormatID="AS_00040207" audioStreamFormatName="PCM_FuMa_T" formatLabel="0001" formatDefinition="PCM">
+        <audioStreamFormat audioStreamFormatID="AS_00040207" audioStreamFormatName="PCM_FuMa_R" formatLabel="0001" formatDefinition="PCM">
           <audioChannelFormatIDRef>AC_00040207</audioChannelFormatIDRef>
           <audioTrackFormatIDRef>AT_00040207_01</audioTrackFormatIDRef>
         </audioStreamFormat>
-        <audioStreamFormat audioStreamFormatID="AS_00040208" audioStreamFormatName="PCM_FuMa_U" formatLabel="0001" formatDefinition="PCM">
+        <audioStreamFormat audioStreamFormatID="AS_00040208" audioStreamFormatName="PCM_FuMa_S" formatLabel="0001" formatDefinition="PCM">
           <audioChannelFormatIDRef>AC_00040208</audioChannelFormatIDRef>
           <audioTrackFormatIDRef>AT_00040208_01</audioTrackFormatIDRef>
         </audioStreamFormat>
-        <audioStreamFormat audioStreamFormatID="AS_00040209" audioStreamFormatName="PCM_FuMa_V" formatLabel="0001" formatDefinition="PCM">
+        <audioStreamFormat audioStreamFormatID="AS_00040209" audioStreamFormatName="PCM_FuMa_U" formatLabel="0001" formatDefinition="PCM">
           <audioChannelFormatIDRef>AC_00040209</audioChannelFormatIDRef>
           <audioTrackFormatIDRef>AT_00040209_01</audioTrackFormatIDRef>
         </audioStreamFormat>
-        <audioStreamFormat audioStreamFormatID="AS_0004020a" audioStreamFormatName="PCM_FuMa_K" formatLabel="0001" formatDefinition="PCM">
+        <audioStreamFormat audioStreamFormatID="AS_0004020a" audioStreamFormatName="PCM_FuMa_Q" formatLabel="0001" formatDefinition="PCM">
           <audioChannelFormatIDRef>AC_0004020a</audioChannelFormatIDRef>
           <audioTrackFormatIDRef>AT_0004020a_01</audioTrackFormatIDRef>
         </audioStreamFormat>
-        <audioStreamFormat audioStreamFormatID="AS_0004020b" audioStreamFormatName="PCM_FuMa_L" formatLabel="0001" formatDefinition="PCM">
+        <audioStreamFormat audioStreamFormatID="AS_0004020b" audioStreamFormatName="PCM_FuMa_O" formatLabel="0001" formatDefinition="PCM">
           <audioChannelFormatIDRef>AC_0004020b</audioChannelFormatIDRef>
           <audioTrackFormatIDRef>AT_0004020b_01</audioTrackFormatIDRef>
         </audioStreamFormat>
@@ -3755,19 +3755,19 @@
           <audioChannelFormatIDRef>AC_0004020c</audioChannelFormatIDRef>
           <audioTrackFormatIDRef>AT_0004020c_01</audioTrackFormatIDRef>
         </audioStreamFormat>
-        <audioStreamFormat audioStreamFormatID="AS_0004020d" audioStreamFormatName="PCM_FuMa_N" formatLabel="0001" formatDefinition="PCM">
+        <audioStreamFormat audioStreamFormatID="AS_0004020d" audioStreamFormatName="PCM_FuMa_K" formatLabel="0001" formatDefinition="PCM">
           <audioChannelFormatIDRef>AC_0004020d</audioChannelFormatIDRef>
           <audioTrackFormatIDRef>AT_0004020d_01</audioTrackFormatIDRef>
         </audioStreamFormat>
-        <audioStreamFormat audioStreamFormatID="AS_0004020e" audioStreamFormatName="PCM_FuMa_O" formatLabel="0001" formatDefinition="PCM">
+        <audioStreamFormat audioStreamFormatID="AS_0004020e" audioStreamFormatName="PCM_FuMa_L" formatLabel="0001" formatDefinition="PCM">
           <audioChannelFormatIDRef>AC_0004020e</audioChannelFormatIDRef>
           <audioTrackFormatIDRef>AT_0004020e_01</audioTrackFormatIDRef>
         </audioStreamFormat>
-        <audioStreamFormat audioStreamFormatID="AS_0004020f" audioStreamFormatName="PCM_FuMa_P" formatLabel="0001" formatDefinition="PCM">
+        <audioStreamFormat audioStreamFormatID="AS_0004020f" audioStreamFormatName="PCM_FuMa_N" formatLabel="0001" formatDefinition="PCM">
           <audioChannelFormatIDRef>AC_0004020f</audioChannelFormatIDRef>
           <audioTrackFormatIDRef>AT_0004020f_01</audioTrackFormatIDRef>
         </audioStreamFormat>
-        <audioStreamFormat audioStreamFormatID="AS_00040210" audioStreamFormatName="PCM_FuMa_Q" formatLabel="0001" formatDefinition="PCM">
+        <audioStreamFormat audioStreamFormatID="AS_00040210" audioStreamFormatName="PCM_FuMa_P" formatLabel="0001" formatDefinition="PCM">
           <audioChannelFormatIDRef>AC_00040210</audioChannelFormatIDRef>
           <audioTrackFormatIDRef>AT_00040210_01</audioTrackFormatIDRef>
         </audioStreamFormat>
@@ -4626,49 +4626,49 @@
         <audioTrackFormat audioTrackFormatID="AT_00040201_01" audioTrackFormatName="PCM_FuMa_W" formatLabel="0001" formatDefinition="PCM">
           <audioStreamFormatIDRef>AS_00040201</audioStreamFormatIDRef>
         </audioTrackFormat>
-        <audioTrackFormat audioTrackFormatID="AT_00040202_01" audioTrackFormatName="PCM_FuMa_X" formatLabel="0001" formatDefinition="PCM">
+        <audioTrackFormat audioTrackFormatID="AT_00040202_01" audioTrackFormatName="PCM_FuMa_Y" formatLabel="0001" formatDefinition="PCM">
           <audioStreamFormatIDRef>AS_00040202</audioStreamFormatIDRef>
         </audioTrackFormat>
-        <audioTrackFormat audioTrackFormatID="AT_00040203_01" audioTrackFormatName="PCM_FuMa_Y" formatLabel="0001" formatDefinition="PCM">
+        <audioTrackFormat audioTrackFormatID="AT_00040203_01" audioTrackFormatName="PCM_FuMa_Z" formatLabel="0001" formatDefinition="PCM">
           <audioStreamFormatIDRef>AS_00040203</audioStreamFormatIDRef>
         </audioTrackFormat>
-        <audioTrackFormat audioTrackFormatID="AT_00040204_01" audioTrackFormatName="PCM_FuMa_Z" formatLabel="0001" formatDefinition="PCM">
+        <audioTrackFormat audioTrackFormatID="AT_00040204_01" audioTrackFormatName="PCM_FuMa_X" formatLabel="0001" formatDefinition="PCM">
           <audioStreamFormatIDRef>AS_00040204</audioStreamFormatIDRef>
         </audioTrackFormat>
-        <audioTrackFormat audioTrackFormatID="AT_00040205_01" audioTrackFormatName="PCM_FuMa_R" formatLabel="0001" formatDefinition="PCM">
+        <audioTrackFormat audioTrackFormatID="AT_00040205_01" audioTrackFormatName="PCM_FuMa_V" formatLabel="0001" formatDefinition="PCM">
           <audioStreamFormatIDRef>AS_00040205</audioStreamFormatIDRef>
         </audioTrackFormat>
-        <audioTrackFormat audioTrackFormatID="AT_00040206_01" audioTrackFormatName="PCM_FuMa_S" formatLabel="0001" formatDefinition="PCM">
+        <audioTrackFormat audioTrackFormatID="AT_00040206_01" audioTrackFormatName="PCM_FuMa_T" formatLabel="0001" formatDefinition="PCM">
           <audioStreamFormatIDRef>AS_00040206</audioStreamFormatIDRef>
         </audioTrackFormat>
-        <audioTrackFormat audioTrackFormatID="AT_00040207_01" audioTrackFormatName="PCM_FuMa_T" formatLabel="0001" formatDefinition="PCM">
+        <audioTrackFormat audioTrackFormatID="AT_00040207_01" audioTrackFormatName="PCM_FuMa_R" formatLabel="0001" formatDefinition="PCM">
           <audioStreamFormatIDRef>AS_00040207</audioStreamFormatIDRef>
         </audioTrackFormat>
-        <audioTrackFormat audioTrackFormatID="AT_00040208_01" audioTrackFormatName="PCM_FuMa_U" formatLabel="0001" formatDefinition="PCM">
+        <audioTrackFormat audioTrackFormatID="AT_00040208_01" audioTrackFormatName="PCM_FuMa_S" formatLabel="0001" formatDefinition="PCM">
           <audioStreamFormatIDRef>AS_00040208</audioStreamFormatIDRef>
         </audioTrackFormat>
-        <audioTrackFormat audioTrackFormatID="AT_00040209_01" audioTrackFormatName="PCM_FuMa_V" formatLabel="0001" formatDefinition="PCM">
+        <audioTrackFormat audioTrackFormatID="AT_00040209_01" audioTrackFormatName="PCM_FuMa_U" formatLabel="0001" formatDefinition="PCM">
           <audioStreamFormatIDRef>AS_00040209</audioStreamFormatIDRef>
         </audioTrackFormat>
-        <audioTrackFormat audioTrackFormatID="AT_0004020a_01" audioTrackFormatName="PCM_FuMa_K" formatLabel="0001" formatDefinition="PCM">
+        <audioTrackFormat audioTrackFormatID="AT_0004020a_01" audioTrackFormatName="PCM_FuMa_Q" formatLabel="0001" formatDefinition="PCM">
           <audioStreamFormatIDRef>AS_0004020a</audioStreamFormatIDRef>
         </audioTrackFormat>
-        <audioTrackFormat audioTrackFormatID="AT_0004020b_01" audioTrackFormatName="PCM_FuMa_L" formatLabel="0001" formatDefinition="PCM">
+        <audioTrackFormat audioTrackFormatID="AT_0004020b_01" audioTrackFormatName="PCM_FuMa_O" formatLabel="0001" formatDefinition="PCM">
           <audioStreamFormatIDRef>AS_0004020b</audioStreamFormatIDRef>
         </audioTrackFormat>
         <audioTrackFormat audioTrackFormatID="AT_0004020c_01" audioTrackFormatName="PCM_FuMa_M" formatLabel="0001" formatDefinition="PCM">
           <audioStreamFormatIDRef>AS_0004020c</audioStreamFormatIDRef>
         </audioTrackFormat>
-        <audioTrackFormat audioTrackFormatID="AT_0004020d_01" audioTrackFormatName="PCM_FuMa_N" formatLabel="0001" formatDefinition="PCM">
+        <audioTrackFormat audioTrackFormatID="AT_0004020d_01" audioTrackFormatName="PCM_FuMa_K" formatLabel="0001" formatDefinition="PCM">
           <audioStreamFormatIDRef>AS_0004020d</audioStreamFormatIDRef>
         </audioTrackFormat>
-        <audioTrackFormat audioTrackFormatID="AT_0004020e_01" audioTrackFormatName="PCM_FuMa_O" formatLabel="0001" formatDefinition="PCM">
+        <audioTrackFormat audioTrackFormatID="AT_0004020e_01" audioTrackFormatName="PCM_FuMa_L" formatLabel="0001" formatDefinition="PCM">
           <audioStreamFormatIDRef>AS_0004020e</audioStreamFormatIDRef>
         </audioTrackFormat>
-        <audioTrackFormat audioTrackFormatID="AT_0004020f_01" audioTrackFormatName="PCM_FuMa_P" formatLabel="0001" formatDefinition="PCM">
+        <audioTrackFormat audioTrackFormatID="AT_0004020f_01" audioTrackFormatName="PCM_FuMa_N" formatLabel="0001" formatDefinition="PCM">
           <audioStreamFormatIDRef>AS_0004020f</audioStreamFormatIDRef>
         </audioTrackFormat>
-        <audioTrackFormat audioTrackFormatID="AT_00040210_01" audioTrackFormatName="PCM_FuMa_Q" formatLabel="0001" formatDefinition="PCM">
+        <audioTrackFormat audioTrackFormatID="AT_00040210_01" audioTrackFormatName="PCM_FuMa_P" formatLabel="0001" formatDefinition="PCM">
           <audioStreamFormatIDRef>AS_00040210</audioStreamFormatIDRef>
         </audioTrackFormat>
       </audioFormatExtended>

--- a/src/common_definitions.cpp
+++ b/src/common_definitions.cpp
@@ -5,17 +5,6 @@
 #include <iostream>
 #include <iomanip>
 
-namespace {
-    std::string intToHex(int i )
-    {
-      std::stringstream stream;
-      stream << std::setfill ('0')
-             << std::setw(2)
-             << std::hex << i;
-      return stream.str();
-    }
-}
-
 namespace adm {
 
   const std::map<std::string, adm::AudioPackFormatId>
@@ -143,21 +132,24 @@ namespace adm {
           "U+045", "U-045", "U+135", "U-135"}}};
   }
 
-  const adm::AudioTrackFormatId
-  audioTrackFormatHoaLookup(int order, int degree, std::string normalization){
-      std::string normalizationTypeValue = "400";
-      if(normalization == "SN3D"){
-          normalizationTypeValue = "400";
-      } else if(normalization == "N3D") {
-          normalizationTypeValue = "401";
-      } else if(normalization == "FuMa") {
-          normalizationTypeValue = "402";
-      } else {
-          throw std::invalid_argument("Not a supported normalization value.");
-      }
-      int channelNumber = order*order + order + degree + 1; // ACN starts from 0, while AudioTrackFormatId starts from 1
-      std::string hexChannelNumber = intToHex(channelNumber);
-      return adm::parseAudioTrackFormatId("AT_000"+normalizationTypeValue+hexChannelNumber+"_"+"01");
+  const adm::AudioTrackFormatId audioTrackFormatHoaLookup(
+      int order, int degree, std::string normalization) {
+    int normalizationTypeValue;
+    if (normalization == "SN3D") {
+      normalizationTypeValue = 0;
+    } else if (normalization == "N3D") {
+      normalizationTypeValue = 1;
+    } else if (normalization == "FuMa") {
+      normalizationTypeValue = 2;
+    } else {
+      throw std::invalid_argument("Not a supported normalization value.");
+    }
+    // ACN starts from 0, while AudioTrackFormatId starts from 1
+    int trackFormatIdValue =
+        order * order + order + degree + 1 + normalizationTypeValue * 0x100;
+    return adm::AudioTrackFormatId(TypeDefinition::HOA,
+                                   AudioTrackFormatIdValue(trackFormatIdValue),
+                                   AudioTrackFormatIdCounter(1));
   }
 
   std::shared_ptr<Document> getCommonDefinitions() {

--- a/src/common_definitions.cpp
+++ b/src/common_definitions.cpp
@@ -2,6 +2,19 @@
 #include "resources.hpp"
 #include "adm/private/xml_parser.hpp"
 #include "adm/utilities/copy.hpp"
+#include <iostream>
+#include <iomanip>
+
+namespace {
+    std::string intToHex(int i )
+    {
+      std::stringstream stream;
+      stream << std::setfill ('0')
+             << std::setw(2)
+             << std::hex << i;
+      return stream.str();
+    }
+}
 
 namespace adm {
 
@@ -18,6 +31,24 @@ namespace adm {
         {"9+10+3", adm::parseAudioPackFormatId("AP_00010009")},
         // {"0+7+0", adm::parseAudioPackFormatId("")},
         // {"4+7+0", adm::parseAudioPackFormatId("")},
+        {"SN3D-Order1-3D", adm::parseAudioPackFormatId("AP_00040001")},
+        {"SN3D-Order2-3D", adm::parseAudioPackFormatId("AP_00040002")},
+        {"SN3D-Order3-3D", adm::parseAudioPackFormatId("AP_00040003")},
+        {"SN3D-Order4-3D", adm::parseAudioPackFormatId("AP_00040004")},
+        {"SN3D-Order5-3D", adm::parseAudioPackFormatId("AP_00040005")},
+        {"SN3D-Order6-3D", adm::parseAudioPackFormatId("AP_00040006")},
+        {"N3D-Order1-3D", adm::parseAudioPackFormatId("AP_00040011")},
+        {"N3D-Order2-3D", adm::parseAudioPackFormatId("AP_00040012")},
+        {"N3D-Order3-3D", adm::parseAudioPackFormatId("AP_00040013")},
+        {"N3D-Order4-3D", adm::parseAudioPackFormatId("AP_00040014")},
+        {"N3D-Order5-3D", adm::parseAudioPackFormatId("AP_00040015")},
+        {"N3D-Order6-3D", adm::parseAudioPackFormatId("AP_00040016")},
+        {"FuMa-Order1-3D", adm::parseAudioPackFormatId("AP_00040021")},
+        {"FuMa-Order2-3D", adm::parseAudioPackFormatId("AP_00040022")},
+        {"FuMa-Order3-3D", adm::parseAudioPackFormatId("AP_00040023")},
+        {"FuMa-Order4-3D", adm::parseAudioPackFormatId("AP_00040024")},
+        {"FuMa-Order5-3D", adm::parseAudioPackFormatId("AP_00040025")},
+        {"FuMa-Order6-3D", adm::parseAudioPackFormatId("AP_00040026")},
     };
   };
 
@@ -110,6 +141,23 @@ namespace adm {
         {"4+7+0",
          {"M+030", "M-030", "M+000", "LFE1", "M+090", "M-090", "M+135", "M-135",
           "U+045", "U-045", "U+135", "U-135"}}};
+  }
+
+  const adm::AudioTrackFormatId
+  audioTrackFormatHoaLookup(int order, int degree, std::string normalization){
+      std::string normalizationTypeValue = "400";
+      if(normalization == "SN3D"){
+          normalizationTypeValue = "400";
+      } else if(normalization == "N3D") {
+          normalizationTypeValue = "401";
+      } else if(normalization == "FuMa") {
+          normalizationTypeValue = "402";
+      } else {
+          throw std::invalid_argument("Not a supported normalization value.");
+      }
+      int channelNumber = order*order + order + degree + 1; // ACN starts from 0, while AudioTrackFormatId starts from 1
+      std::string hexChannelNumber = intToHex(channelNumber);
+      return adm::parseAudioTrackFormatId("AT_000"+normalizationTypeValue+hexChannelNumber+"_"+"01");
   }
 
   std::shared_ptr<Document> getCommonDefinitions() {

--- a/tests/adm_common_definitions_tests.cpp
+++ b/tests/adm_common_definitions_tests.cpp
@@ -7,3 +7,48 @@ TEST_CASE("basic_document") {
   // create a basic document
   { auto commonDefinitions = getCommonDefinitions(); }
 }
+
+TEST_CASE("Parse HOA") {
+    using namespace adm;
+
+
+    auto admDocument = Document::create();
+    addCommonDefinitionsTo(admDocument);
+
+    auto packFormatLookup = audioPackFormatLookupTable();
+    auto trackFormatLookup = audioTrackFormatLookupTable();
+    auto sn3d_order1_3d = admDocument->lookup(packFormatLookup.at("SN3D-Order1-3D"));
+
+    auto name = sn3d_order1_3d.get()->get<AudioPackFormatName>();
+    REQUIRE(name == "3D_order1_SN3D_ACN");
+
+    auto type = sn3d_order1_3d.get()->get<TypeDescriptor>();
+    REQUIRE(type == 4);
+
+    auto fuma_order2_3d = admDocument->lookup(packFormatLookup.at("FuMa-Order2-3D"));
+
+    name = fuma_order2_3d.get()->get<AudioPackFormatName>();
+    REQUIRE(name == "3D_order2_FuMa");
+
+    type = fuma_order2_3d.get()->get<TypeDescriptor>();
+    REQUIRE(type == 4);
+}
+
+TEST_CASE("HOA Track Lookup") {
+    using namespace adm;
+
+    auto admDocument = adm::Document::create();
+    addCommonDefinitionsTo(admDocument);
+
+    auto audioTrackFormatId_SN3D = audioTrackFormatHoaLookup(0, 0, "SN3D");
+    auto label_SN3D = formatId(audioTrackFormatId_SN3D);
+    REQUIRE(label_SN3D == "AT_00040001_01");
+
+    auto audioTrackFormatId_N3D = audioTrackFormatHoaLookup(7, 6, "N3D");
+    auto label_N3D = formatId(audioTrackFormatId_N3D);
+    REQUIRE(label_N3D == "AT_0004013f_01");
+
+    auto audioTrackFormatId_FuMa = audioTrackFormatHoaLookup(3, -1, "FuMa");
+    auto label_FuMa = formatId(audioTrackFormatId_FuMa);
+    REQUIRE(label_FuMa == "AT_0004020c_01");
+}


### PR DESCRIPTION
Dave mentioned that it would be useful to add similar common definition lookup functions for `HOA` as already exists for `DirectSpeakers`.

In the case of `audioPackFormat` the `HOA` packs have been included in the existing lookup table. For `audioTrackFormat` Tom suggested using the `order*order + order + degree` equation to find track Ids for `HOA`, as the track label doesn't carry any inherent meaning - as it does for `DirectSpeakers`.

`ADM_EXPORT` prefix added to `audioTrackFormatLookupTable ` and `audioPackFormatLookupTable` to allow them to be used in tests.

The common definitions xml has also been updated to most recent version.