### PR TITLE
Improve logic and speed in AudioChannelFormat::assignId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - added support to lookup HOA common definitions AudioPackFormatIDs and AudioTrackFormatIDs
 
 ### Changed
+- improved `AudioChannelFormat::assignId` logic - huge performance increase for large documents
 
 ### Fixed
 - fixed bug were not all references were removed if AudioPackFormat was removed from document

--- a/include/adm/elements/audio_channel_format.hpp
+++ b/include/adm/elements/audio_channel_format.hpp
@@ -387,7 +387,7 @@ namespace adm {
         throw std::runtime_error("Invalid ID - incorrect type descriptor");
 
       auto thisValue = thisId.template get<AudioBlockFormatIdValue>();
-      if (thisTypeDescriptor != expectedTypeDescriptor)
+      if (thisValue != expectedValue)
         throw std::runtime_error("Invalid ID - incorrect value");
 
       if (previousBlock) {

--- a/src/elements/audio_channel_format.cpp
+++ b/src/elements/audio_channel_format.cpp
@@ -88,26 +88,46 @@ namespace adm {
 
   // ---- AudioBlocks ---- //
   void AudioChannelFormat::add(AudioBlockFormatDirectSpeakers blockFormat) {
-    assignId(blockFormat);
+    if (audioBlockFormatsDirectSpeakers_.empty()) {
+      assignId(blockFormat);
+    } else {
+      assignId(blockFormat, &audioBlockFormatsDirectSpeakers_.back());
+    }
     audioBlockFormatsDirectSpeakers_.push_back(blockFormat);
   }
   void AudioChannelFormat::add(AudioBlockFormatMatrix blockFormat) {
-    assignId(blockFormat);
+    if (audioBlockFormatsMatrix_.empty()) {
+      assignId(blockFormat);
+    } else {
+      assignId(blockFormat, &audioBlockFormatsMatrix_.back());
+    }
     audioBlockFormatsMatrix_.push_back(blockFormat);
   }
 
   void AudioChannelFormat::add(AudioBlockFormatObjects blockFormat) {
-    assignId(blockFormat);
+    if (audioBlockFormatsObjects_.empty()) {
+      assignId(blockFormat);
+    } else {
+      assignId(blockFormat, &audioBlockFormatsObjects_.back());
+    }
     audioBlockFormatsObjects_.push_back(blockFormat);
   }
 
   void AudioChannelFormat::add(AudioBlockFormatHoa blockFormat) {
-    assignId(blockFormat);
+    if (audioBlockFormatsHoa_.empty()) {
+      assignId(blockFormat);
+    } else {
+      assignId(blockFormat, &audioBlockFormatsHoa_.back());
+    }
     audioBlockFormatsHoa_.push_back(blockFormat);
   }
 
   void AudioChannelFormat::add(AudioBlockFormatBinaural blockFormat) {
-    assignId(blockFormat);
+    if (audioBlockFormatsBinaural_.empty()) {
+      assignId(blockFormat);
+    } else {
+      assignId(blockFormat, &audioBlockFormatsBinaural_.back());
+    }
     audioBlockFormatsBinaural_.push_back(blockFormat);
   }
 


### PR DESCRIPTION
assignId was very slow when adding lots of successive blocks. This is due to two nested loops; one in assignId to generate and ID, and one in idUsed to see if it is free. Therefore the time to perform this operation grew exponentially with the number of blocks added.

This PR has linear complexity since it simply refers to the ID of the preceding block to generate a new ID. It also checks that when blocks with ID's already assigned are added, they are one greater than the preceding block.

With this logic, it ensures that the counter portion of block ID's are consecutive as they are added. It does not enforce that the first block has a counter portion of 1, since this isn't necessarily the case in S-ADM.