### PR TITLE
simplify auto_base with C++17 parameter pack expansion in using

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.8)
 
 ############################################################
 # set global paths

--- a/include/adm/detail/auto_base.hpp
+++ b/include/adm/detail/auto_base.hpp
@@ -43,9 +43,10 @@ namespace adm {
 
     /// base class with set/get/has methods for a required parameter of type T
     /// combine these together using HasParameters
-    template <typename T,
-              typename Tag = typename detail::ParameterTraits<T>::tag>
+    template <typename T>
     class RequiredParameter {
+      using Tag = typename detail::ParameterTraits<T>::tag;
+
      public:
       using ParameterType = T;
       static constexpr Flags flags = Flags::HAS_GET_SET_HAS;
@@ -61,9 +62,10 @@ namespace adm {
     /// base class with set/get/has/isDefault/unset methods for an optional
     /// parameter of type T with no default. combine these together using
     /// HasParameters
-    template <typename T,
-              typename Tag = typename detail::ParameterTraits<T>::tag>
+    template <typename T>
     class OptionalParameter {
+      using Tag = typename detail::ParameterTraits<T>::tag;
+
      public:
       using ParameterType = T;
       static constexpr Flags flags =
@@ -82,9 +84,10 @@ namespace adm {
     /// base class with set/get/has/isDefault/unset methods for an optional
     /// parameter of type T, which has a default provided by DefaultParameter.
     /// combine these together using HasParameters
-    template <typename T,
-              typename Tag = typename detail::ParameterTraits<T>::tag>
+    template <typename T>
     class DefaultParameter {
+      using Tag = typename detail::ParameterTraits<T>::tag;
+
      public:
       using ParameterType = T;
       static constexpr Flags flags =
@@ -112,9 +115,9 @@ namespace adm {
     /// base class for storage of multiple elements in a std::vector.
     /// T should be a std::vector<Something>, as this is what the tag is
     /// associated with.
-    template <typename T,
-              typename Tag = typename detail::ParameterTraits<T>::tag>
+    template <typename T>
     class VectorParameter {
+      using Tag = typename detail::ParameterTraits<T>::tag;
       using Value = typename T::value_type;
 
      public:

--- a/include/adm/detail/auto_base.hpp
+++ b/include/adm/detail/auto_base.hpp
@@ -326,7 +326,7 @@ namespace adm {
     /// When using this with OptionalParameter<V>, the following classes should
     /// be explicitly instantiated:
     /// - OptionalParameter<V> (not VariantParameter<...>)
-    /// - One VariantParameter<OptionalParameter<V>, T> for each T in V.
+    /// - One VariantTypeParameter<OptionalParameter<V>, T> for each T in V.
     template <typename VariantParam>
     using VariantParameter = typename VariantParameterHelper<
         VariantParam, typename VariantParam::ParameterType>::type;

--- a/include/adm/detail/auto_base_detail.hpp
+++ b/include/adm/detail/auto_base_detail.hpp
@@ -1,31 +1,105 @@
+#pragma once
+
+#include "adm/detail/enum_bitmask.hpp"
+#include <type_traits>
 
 namespace adm {
   namespace detail {
-    /// Combine A and B using F if defined_in_both, otherwise Base
-    template <bool defined_in_both,
-              template <typename A, typename B, typename Base> class F,
-              typename A, typename B, typename Base>
-    struct ApplyIfT;
+    /// represent a list of types as a single type
+    template <typename... T>
+    class TypeList {};
 
-    template <template <typename A, typename B, typename Base> class F,
-              typename A, typename B, typename Base>
-    struct ApplyIfT<false, F, A, B, Base> {
-      using type = Base;
+    template <typename Head, typename Tail>
+    struct ConsImpl;
+
+    template <typename Head, typename... Tail>
+    struct ConsImpl<Head, TypeList<Tail...>> {
+      using type = TypeList<Head, Tail...>;
     };
 
-    template <template <typename A, typename B, typename Base> class F,
-              typename A, typename B, typename Base>
-    struct ApplyIfT<true, F, A, B, Base> {
-      using type = F<A, B, Base>;
+    /// prepend Head to TypeList Tail
+    template <typename Head, typename Tail>
+    using Cons = typename ConsImpl<Head, Tail>::type;
+
+    /// specify which method a parameter has
+    enum class Flags : unsigned {
+      HAS_GET_SET_HAS = 1,
+      HAS_ISDEFAULT_UNSET = 2,
+      HAS_ADD_REMOVE = 4,
     };
 
-    template <bool defined_in_both,
-              template <typename A, typename B, typename Base> class F,
-              typename A, typename B, typename Base>
-    using ApplyIf = typename ApplyIfT<defined_in_both, F, A, B, Base>::type;
+    template <>
+    struct EnableBitMaskOperators<Flags> : public std::true_type {};
 
-    /// subclass of A and B
-    template <typename A, typename B>
-    struct CombineRaw : public A, public B {};
+    /// From a list of bases as a TypeList, select the ones which have exactly
+    /// the specified flags
+    template <typename Bases, Flags flags, typename Enable = void>
+    struct BasesWithFlags;
+
+    // recursive case when the head has the requested flags
+    template <typename Head, typename... Tail, Flags flags>
+    struct BasesWithFlags<TypeList<Head, Tail...>, flags,
+                          std::enable_if_t<Head::flags == flags>> {
+      using type =
+          Cons<Head, typename BasesWithFlags<TypeList<Tail...>, flags>::type>;
+    };
+
+    // recursive case when the head does not have the requested flags
+    template <typename Head, typename... Tail, Flags flags>
+    struct BasesWithFlags<TypeList<Head, Tail...>, flags,
+                          std::enable_if_t<Head::flags != flags>> {
+      using type = typename BasesWithFlags<TypeList<Tail...>, flags>::type;
+    };
+
+    // recursive case
+    template <Flags flags>
+    struct BasesWithFlags<TypeList<>, flags> {
+      using type = TypeList<>;
+    };
+
+    /// a class inheriting publicly from classes in Bases (a TypeList), with
+    /// using declarations for classes specified in the other TypeList
+    /// parameters; e.g. classes in AddRemoveBases get a using declaration for
+    /// add and remove
+    ///
+    /// note that the bases are selected based on the combinations of flags
+    /// that are actually used, so each base is only in one list, to make the
+    /// type names smaller. more lists may need to be added to accommodate new
+    /// types of parameters if they use different subsets of methods
+    template <
+        typename Bases,
+        typename GetSetHasBases =
+            typename BasesWithFlags<Bases, Flags::HAS_GET_SET_HAS>::type,
+        typename IsDefaultUnsetBases = typename BasesWithFlags<
+            Bases, Flags::HAS_GET_SET_HAS | Flags::HAS_ISDEFAULT_UNSET>::type,
+        typename AddRemoveBases = typename BasesWithFlags<
+            Bases, Flags::HAS_GET_SET_HAS | Flags::HAS_ISDEFAULT_UNSET |
+                       Flags::HAS_ADD_REMOVE>::type>
+    class Combine;
+
+    template <typename... Bases, typename... GetSetHasBases,
+              typename... IsDefaultUnsetBases, typename... AddRemoveBases>
+    class Combine<TypeList<Bases...>, TypeList<GetSetHasBases...>,
+                  TypeList<IsDefaultUnsetBases...>, TypeList<AddRemoveBases...>>
+        : public Bases... {
+     public:
+      using GetSetHasBases::get...;
+      using GetSetHasBases::set...;
+      using GetSetHasBases::has...;
+
+      using IsDefaultUnsetBases::get...;
+      using IsDefaultUnsetBases::set...;
+      using IsDefaultUnsetBases::has...;
+      using IsDefaultUnsetBases::isDefault...;
+      using IsDefaultUnsetBases::unset...;
+
+      using AddRemoveBases::get...;
+      using AddRemoveBases::set...;
+      using AddRemoveBases::has...;
+      using AddRemoveBases::isDefault...;
+      using AddRemoveBases::unset...;
+      using AddRemoveBases::add...;
+      using AddRemoveBases::remove...;
+    };
   }  // namespace detail
 }  // namespace adm

--- a/include/adm/detail/enum_bitmask.hpp
+++ b/include/adm/detail/enum_bitmask.hpp
@@ -18,7 +18,7 @@ namespace adm {
 
 template <typename Enum>
 typename std::enable_if<adm::detail::EnableBitMaskOperators<Enum>::value,
-                        Enum>::type
+                        Enum>::type constexpr
 operator|(Enum lhs, Enum rhs) {
   using T = typename std::underlying_type<Enum>::type;
   return static_cast<Enum>(static_cast<T>(lhs) | static_cast<T>(rhs));
@@ -26,7 +26,7 @@ operator|(Enum lhs, Enum rhs) {
 
 template <typename Enum>
 typename std::enable_if<adm::detail::EnableBitMaskOperators<Enum>::value,
-                        Enum>::type
+                        Enum>::type constexpr
 operator&(Enum lhs, Enum rhs) {
   using T = typename std::underlying_type<Enum>::type;
   return static_cast<Enum>(static_cast<T>(lhs) & static_cast<T>(rhs));
@@ -34,7 +34,7 @@ operator&(Enum lhs, Enum rhs) {
 
 template <typename Enum>
 typename std::enable_if<adm::detail::EnableBitMaskOperators<Enum>::value,
-                        Enum>::type
+                        Enum>::type constexpr
 operator^(Enum lhs, Enum rhs) {
   using T = typename std::underlying_type<Enum>::type;
   return static_cast<Enum>(static_cast<T>(lhs) ^ static_cast<T>(rhs));
@@ -42,7 +42,7 @@ operator^(Enum lhs, Enum rhs) {
 
 template <typename Enum>
 typename std::enable_if<adm::detail::EnableBitMaskOperators<Enum>::value,
-                        Enum>::type
+                        Enum>::type constexpr
 operator~(Enum lhs) {
   using T = typename std::underlying_type<Enum>::type;
   return static_cast<Enum>(~static_cast<T>(lhs));
@@ -50,7 +50,7 @@ operator~(Enum lhs) {
 
 template <typename Enum>
 typename std::enable_if<adm::detail::EnableBitMaskOperators<Enum>::value,
-                        Enum&>::type
+                        Enum&>::type constexpr
 operator|=(Enum& lhs, Enum rhs) {
   using T = typename std::underlying_type<Enum>::type;
   lhs = static_cast<Enum>(static_cast<T>(lhs) | static_cast<T>(rhs));
@@ -59,7 +59,7 @@ operator|=(Enum& lhs, Enum rhs) {
 
 template <typename Enum>
 typename std::enable_if<adm::detail::EnableBitMaskOperators<Enum>::value,
-                        Enum&>::type
+                        Enum&>::type constexpr
 operator&=(Enum& lhs, Enum rhs) {
   using T = typename std::underlying_type<Enum>::type;
   lhs = static_cast<Enum>(static_cast<T>(lhs) & static_cast<T>(rhs));
@@ -68,7 +68,7 @@ operator&=(Enum& lhs, Enum rhs) {
 
 template <typename Enum>
 typename std::enable_if<adm::detail::EnableBitMaskOperators<Enum>::value,
-                        Enum&>::type
+                        Enum&>::type constexpr
 operator^=(Enum& lhs, Enum rhs) {
   using T = typename std::underlying_type<Enum>::type;
   lhs = static_cast<Enum>(static_cast<T>(lhs) ^ static_cast<T>(rhs));

--- a/include/adm/detail/type_traits.hpp
+++ b/include/adm/detail/type_traits.hpp
@@ -9,7 +9,6 @@ namespace adm {
   namespace detail {               \
     template <>                    \
     struct ParameterTraits<TYPE> { \
-      struct TAG {};               \
       typedef TAG tag;             \
     };                             \
   }

--- a/include/adm/elements/audio_block_format_direct_speakers.hpp
+++ b/include/adm/elements/audio_block_format_direct_speakers.hpp
@@ -22,15 +22,17 @@ namespace adm {
   struct SpeakerLabelTag {};
   /// @brief NamedType for a speaker label
   using SpeakerLabel = detail::NamedType<std::string, SpeakerLabelTag>;
-  /// @brief NamedType for all speaker labels of an AudioBlockFormat
+  /// @brief type for all speaker labels of an AudioBlockFormat
   using SpeakerLabels = std::vector<SpeakerLabel>;
+  /// @brief Tag for SpeakerLabels
+  struct SpeakerLabelsTag {};
   ADD_TRAIT(SpeakerLabels, SpeakerLabelsTag);
 
   /// @brief NamedType for speaker position in an AudioBlockFormat
   using SpeakerPosition =
       boost::variant<SphericalSpeakerPosition, CartesianSpeakerPosition>;
   struct SpeakerPositionTag {};
-  ADD_TRAIT(SpeakerPosition, SpeakerPostionTag);
+  ADD_TRAIT(SpeakerPosition, SpeakerPositionTag);
 
   namespace detail {
     using AudioBlockFormatDirectSpeakersBase =

--- a/include/adm/elements/dialogue.hpp
+++ b/include/adm/elements/dialogue.hpp
@@ -101,7 +101,7 @@ namespace adm {
   typedef boost::variant<NonDialogueContentKind, DialogueContentKind,
                          MixedContentKind>
       ContentKind;
-
+  struct ContentKindTag {};
   ADD_TRAIT(ContentKind, ContentKindTag);
 
 }  // namespace adm

--- a/include/adm/elements/loudness_metadata.hpp
+++ b/include/adm/elements/loudness_metadata.hpp
@@ -54,6 +54,7 @@ namespace adm {
   struct LoudnessMetadataTag {};
 
   using LoudnessMetadatas = std::vector<LoudnessMetadata>;
+  struct LoudnessMetadatasTag {};
   ADD_TRAIT(LoudnessMetadatas, LoudnessMetadatasTag);
 
   class LoudnessMetadata {

--- a/include/adm/elements/position.hpp
+++ b/include/adm/elements/position.hpp
@@ -221,6 +221,7 @@ namespace adm {
 
   ///@brief Type to hold a SphericalPosition or CartesianPosition
   typedef boost::variant<SphericalPosition, CartesianPosition> Position;
+  struct PositionTag {};
   ADD_TRAIT(Position, PositionTag);
 
   // ---- Free functions ---- //

--- a/include/adm/elements/position_offset.hpp
+++ b/include/adm/elements/position_offset.hpp
@@ -14,15 +14,6 @@
 namespace adm {
 
   namespace detail {
-    using SphericalPositionOffsetBase =
-        HasParameters<OptionalParameter<AzimuthOffset>,
-                      OptionalParameter<ElevationOffset>,
-                      OptionalParameter<DistanceOffset>>;
-
-    using CartesianPositionOffsetBase =
-        HasParameters<OptionalParameter<XOffset>, OptionalParameter<YOffset>,
-                      OptionalParameter<ZOffset>>;
-
     extern template class ADM_EXPORT_TEMPLATE_METHODS
         OptionalParameter<AzimuthOffset>;
     extern template class ADM_EXPORT_TEMPLATE_METHODS
@@ -36,6 +27,15 @@ namespace adm {
         OptionalParameter<YOffset>;
     extern template class ADM_EXPORT_TEMPLATE_METHODS
         OptionalParameter<ZOffset>;
+
+    using SphericalPositionOffsetBase =
+        HasParameters<OptionalParameter<AzimuthOffset>,
+                      OptionalParameter<ElevationOffset>,
+                      OptionalParameter<DistanceOffset>>;
+
+    using CartesianPositionOffsetBase =
+        HasParameters<OptionalParameter<XOffset>, OptionalParameter<YOffset>,
+                      OptionalParameter<ZOffset>>;
 
   }  // namespace detail
 

--- a/include/adm/elements/position_offset.hpp
+++ b/include/adm/elements/position_offset.hpp
@@ -140,6 +140,7 @@ namespace adm {
   /// @brief Type to hold a SphericalPositionOffset or CartesianPositionOffset
   typedef boost::variant<SphericalPositionOffset, CartesianPositionOffset>
       PositionOffset;
+  struct PositionOffsetTag {};
   ADD_TRAIT(PositionOffset, PositionOffsetTag);
 
   // ---- Free functions ---- //

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,16 +98,9 @@ if(ADM_HIDE_INTERNAL_SYMBOLS AND BUILD_SHARED_LIBS)
 endif()
 
 ############################################################
-# enable C++14 support
+# enable C++17 support
 ############################################################
-if (${CMAKE_VERSION} VERSION_LESS "3.8.0")
-  # Note: this is not a complete list of c++ features required by libadm.
-  # What we want is C++14 support and this is a simple way to trigger
-  # this for CMake < 3.8
-  target_compile_features(adm PUBLIC cxx_generic_lambdas)
-else()
-  target_compile_features(adm PUBLIC cxx_std_14)
-endif()
+target_compile_features(adm PUBLIC cxx_std_17)
 set_target_properties(adm PROPERTIES CXX_EXTENSIONS OFF)
 
 include(GenerateExportHeader)


### PR DESCRIPTION
todo:
- [x] update the big comment
- [x] revisit VariantParameter -- perhaps this can now be implemented without the virtual base
    - ~no, this is still required. one possible improvement would be to flatten the list of parameters in `HasParametersImpl`, so that `HasParameters<A, HasParameters<B, C>>` (as produced by `VariantParameter`) is turned into `HasParameters<A, B, C>`, producing fewer `Combine` classes.~
    - yeah, now that i understand how virtual inheritance works, it's obvious that it can be done with CRTP. parameter pack expansion still makes this much cleaner than would have been possible before
- [x] check if the visibility still makes sense now that it's possible to change it all in one place
    - no, this is required because the template wrapper functions have the same names as the tag-dispatched functions
- [x] try auto-detecting which methods to merge, as it may be simpler than using the `Flags` thing
    - no: `VariantParameter` uses `HasParameters`, so the `has` etc. methods are overloaded, which can't be detected without knowing the parameter types
- [x] check impact on binary size and build time
    - shared debug
        - any build time difference is within measurement error for me
        - .so size with debug information: 39.5MB to 38.7MB
        - .so size stripped: 3.2MB to 3.1MB