### PR TITLE
tidy variant checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,10 @@ jobs:
         run: 'echo "${{ runner.workspace }}/b/ninja/src" >> $GITHUB_PATH'
         shell: bash
 
+      - name: Show library sizes
+        run: 'ls -l "${{ runner.workspace }}/b/ninja/src"'
+        shell: bash
+
       - name: 'Run tests'
         run: ctest . --output-on-failure
         working-directory: '${{ runner.workspace }}/b/ninja'

--- a/include/adm/detail/auto_base.hpp
+++ b/include/adm/detail/auto_base.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "adm/detail/auto_base_detail.hpp"
+#include "adm/detail/holds_alternative.hpp"
 #include "adm/detail/type_traits.hpp"
 #include "adm/export.h"
 #include "boost/optional.hpp"
@@ -296,12 +297,13 @@ namespace adm {
 
       using VariantParam::has;
       ADM_BASE_EXPORT bool has(Tag) const {
-        return has(VariantTag{}) && get(VariantTag()).type() == typeid(T);
+        return has(VariantTag{}) && holds_alternative<T>(get(VariantTag()));
       }
 
       using VariantParam::isDefault;
       ADM_BASE_EXPORT bool isDefault(Tag) const {
-        return isDefault(VariantTag()) && get(VariantTag()).type() == typeid(T);
+        return isDefault(VariantTag()) &&
+               holds_alternative<T>(get(VariantTag()));
       }
 
       using VariantParam::unset;

--- a/include/adm/detail/holds_alternative.hpp
+++ b/include/adm/detail/holds_alternative.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <boost/variant/variant_fwd.hpp>
+
+namespace adm {
+  namespace detail {
+
+    /// implementation of variant_type_index; finds the index of type T within
+    /// variant V, or -1 if it's not found
+    template <int i, typename T, typename... Vt>
+    struct VariantTypeIndexImpl;
+
+    // base case when T is found at index i
+    template <int i, typename T, typename... Vt>
+    struct VariantTypeIndexImpl<i, T, T, Vt...> {
+      static constexpr int index = i;
+    };
+
+    // recursive case where T is not at index i
+    template <int i, typename T, typename Th, typename... Vt>
+    struct VariantTypeIndexImpl<i, T, Th, Vt...> {
+      static constexpr int index = VariantTypeIndexImpl<i + 1, T, Vt...>::index;
+    };
+
+    // base case at end of list, to get a nice error
+    template <int i, typename T>
+    struct VariantTypeIndexImpl<i, T> {
+      static constexpr int index = -1;
+    };
+
+    template <typename T, typename V>
+    struct VariantTypeIndexWrapper;
+
+    template <typename T, typename... Vt>
+    struct VariantTypeIndexWrapper<T, boost::variant<Vt...>> {
+      static constexpr int index = VariantTypeIndexImpl<0, T, Vt...>::index;
+    };
+
+    /// get the index of a type T within Variant
+    ///
+    /// for example, variant_type_index<int, boost::variant<int, float>>() == 0
+    ///
+    /// static_asserts if the type is not found
+    template <typename T, typename Variant>
+    constexpr int variant_type_index() {
+      constexpr int index = VariantTypeIndexWrapper<T, Variant>::index;
+      static_assert(index != -1, "variant cannot hold the given type");
+
+      return index;
+    }
+
+    /// check if a variant holds a given type
+    ///
+    /// for example, holds_alternative<int>(boost::variant<int, float>(1)) == true
+    template <typename T, typename Variant>
+    constexpr bool holds_alternative(const Variant &v) {
+      return v.which() == variant_type_index<T, Variant>();
+    }
+
+  }  // namespace detail
+}  // namespace adm

--- a/include/adm/element_variant.hpp
+++ b/include/adm/element_variant.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "adm/detail/holds_alternative.hpp"
 #include "adm/elements.hpp"
 #include <boost/variant.hpp>
 #include <memory>
@@ -26,13 +27,13 @@ namespace adm {
   template <typename VariantType, typename Variant>
   struct IsVariantType {
     bool operator()(const Variant& v) const {
-      return v.type() == typeid(VariantType);
+      return detail::holds_alternative<VariantType>(v);
     }
   };
 
   template <typename VariantType, typename Variant>
   bool isVariantType(const Variant& v) {
-    return v.type() == typeid(VariantType);
+    return detail::holds_alternative<VariantType>(v);
   }
 
   template <typename Element>

--- a/include/adm/elements/time.hpp
+++ b/include/adm/elements/time.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <boost/variant.hpp>
 #include "adm/detail/named_type.hpp"
+#include "adm/detail/holds_alternative.hpp"
 #include "adm/export.h"
 
 namespace adm {
@@ -58,9 +59,11 @@ namespace adm {
     ADM_EXPORT FractionalTime asFractional() const;
 
     bool isNanoseconds() const {
-      return time.type() == typeid(std::chrono::nanoseconds);
+      return detail::holds_alternative<std::chrono::nanoseconds>(time);
     }
-    bool isFractional() const { return time.type() == typeid(FractionalTime); };
+    bool isFractional() const {
+      return detail::holds_alternative<FractionalTime>(time);
+    }
 
     using Variant = boost::variant<std::chrono::nanoseconds, FractionalTime>;
     const Variant& asVariant() const { return time; }

--- a/src/elements/audio_block_format_objects.cpp
+++ b/src/elements/audio_block_format_objects.cpp
@@ -130,11 +130,8 @@ namespace adm {
     }
   }
   void AudioBlockFormatObjects::set(Position position) {
-    if (position.which() == 0) {
-      set(boost::get<SphericalPosition>(position));
-    } else if (position.which() == 1) {
-      set(boost::get<CartesianPosition>(position));
-    }
+    boost::apply_visitor([this](auto p) { set(std::move(p)); },
+                         std::move(position));
   }
   void AudioBlockFormatObjects::set(SphericalPosition position) {
     sphericalPosition_ = position;

--- a/src/elements/audio_content.cpp
+++ b/src/elements/audio_content.cpp
@@ -110,13 +110,7 @@ namespace adm {
     }
   }
   void AudioContent::set(ContentKind kind) {
-    if (kind.which() == 0) {
-      set(boost::get<NonDialogueContentKind>(kind));
-    } else if (kind.which() == 1) {
-      set(boost::get<DialogueContentKind>(kind));
-    } else if (kind.which() == 2) {
-      set(boost::get<MixedContentKind>(kind));
-    }
+    boost::apply_visitor([this](auto k) { set(k); }, kind);
   }
   void AudioContent::set(NonDialogueContentKind kind) {
     unset<DialogueId>();

--- a/src/elements/position.cpp
+++ b/src/elements/position.cpp
@@ -1,3 +1,4 @@
+#include "adm/detail/holds_alternative.hpp"
 #include "adm/elements/position.hpp"
 
 namespace adm {
@@ -123,19 +124,11 @@ namespace adm {
   // ---- FREE FUNCTIONS ---- //
 
   bool isSpherical(const Position& position) {
-    if (position.which() == 0) {
-      return true;
-    } else {
-      return false;
-    }
+    return detail::holds_alternative<SphericalPosition>(position);
   }
 
   bool isCartesian(const Position& position) {
-    if (position.which() == 1) {
-      return true;
-    } else {
-      return false;
-    }
+    return detail::holds_alternative<CartesianPosition>(position);
   }
 
 }  // namespace adm

--- a/src/elements/position_offset.cpp
+++ b/src/elements/position_offset.cpp
@@ -1,4 +1,5 @@
 #include "adm/elements/position_offset.hpp"
+#include "adm/detail/holds_alternative.hpp"
 #include "adm/detail/print_helper.hpp"
 
 namespace adm {
@@ -30,11 +31,11 @@ namespace adm {
   }
 
   bool isSpherical(const PositionOffset& offset) {
-    return offset.type() == typeid(SphericalPositionOffset);
+    return detail::holds_alternative<SphericalPositionOffset>(offset);
   }
 
   bool isCartesian(const PositionOffset& offset) {
-    return offset.type() == typeid(CartesianPositionOffset);
+    return detail::holds_alternative<CartesianPositionOffset>(offset);
   }
 
 }  // namespace adm


### PR DESCRIPTION
closes #191

Perhaps this should be called `isVariantType` instead? It's nice if the name of this matches `std::holds_alternative` which will eventually replace this.

Code size changes are not dramatic, but every little helps.