### PR TITLE
Add Cartesian subelement on Direct Speakers block format

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,13 +41,14 @@ jobs:
         uses: lukka/get-cmake@latest
 
       - name: Restore artifacts, or run vcpkg, build and cache artifacts
-        uses: lukka/run-vcpkg@v7
+        uses: lukka/run-vcpkg@v11
         id: runvcpkg
         with:
-          vcpkgArguments: 'boost-variant boost-optional boost-format boost-functional boost-range boost-iterator boost-rational'
-          vcpkgTriplet: '${{ matrix.triplet }}'
           vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-          vcpkgGitCommitId: '7ad236f60f5f7197e93c4d7f0807622f4899076d'
+          vcpkgGitCommitId: 'b46d9050a9d40d54d24cac3ef8d50402d421f598'
+
+      # Setup MSVC environment on windows, otherwise we get minsys2 / gcc
+      - uses: ilammy/msvc-dev-cmd@v1
 
       - name: 'Install ubuntu dependencies'
         if: matrix.os == 'ubuntu-latest'

--- a/include/adm/elements.hpp
+++ b/include/adm/elements.hpp
@@ -48,6 +48,7 @@
 
 #include "adm/elements/time.hpp"
 #include "adm/elements/audio_programme_ref_screen.hpp"
+#include "adm/elements/cartesian.hpp"
 #include "adm/elements/channel_lock.hpp"
 #include "adm/elements/dialogue.hpp"
 #include "adm/elements/format_descriptor.hpp"

--- a/include/adm/elements/audio_block_format_direct_speakers.hpp
+++ b/include/adm/elements/audio_block_format_direct_speakers.hpp
@@ -68,6 +68,8 @@ namespace adm {
    * +---------------------+------------------------------------+----------------------------+
    * | initializeBlock     | :type:`InitializeBlock`            | :class:`OptionalParameter` |
    * +---------------------+------------------------------------+----------------------------+
+  * | cartesian           | :type:`Cartesian`                  | custom, see below          |
+  * +---------------------+------------------------------------+----------------------------+
    * | position            | - :type:`SpeakerPosition`          | :class:`VariantParameter`  |
    * |                     | - :type:`SphericalSpeakerPosition` |                            |
    * |                     | - :type:`CartesianSpeakerPosition` | :class:`RequiredParameter` |
@@ -83,6 +85,11 @@ namespace adm {
    * | speakerLabel        | :type:`SpeakerLabels`              | :class:`VectorParameter`   |
    * +---------------------+------------------------------------+----------------------------+
    * \endrst
+  *
+  * ``cartesian`` and ``position`` attributes are linked; see
+  * :func:`void set(Cartesian)`, :func:`void set(SpeakerPosition)`,
+  * :func:`void set(CartesianSpeakerPosition)` and
+  * :func:`void set(SphericalSpeakerPosition)`.
    *
    * @warning not all methods are implemented for speakerLabel
    */
@@ -138,6 +145,8 @@ namespace adm {
     ADM_EXPORT void set(Rtime rtime);
     /// @brief Duration setter
     ADM_EXPORT void set(Duration duration);
+    /// @brief Cartesian setter
+    ADM_EXPORT void set(Cartesian cartesian);
     /// @brief CartesianSpeakerPosition setter
     ADM_EXPORT void set(CartesianSpeakerPosition speakerPosition);
     /// @brief SphericalSpeakerPosition setter
@@ -174,6 +183,7 @@ namespace adm {
     ADM_EXPORT Duration get(detail::ParameterTraits<Duration>::tag) const;
     ADM_EXPORT SpeakerLabels
         get(detail::ParameterTraits<SpeakerLabels>::tag) const;
+    ADM_EXPORT Cartesian get(detail::ParameterTraits<Cartesian>::tag) const;
     ADM_EXPORT CartesianSpeakerPosition
         get(detail::ParameterTraits<CartesianSpeakerPosition>::tag) const;
     ADM_EXPORT SphericalSpeakerPosition
@@ -183,6 +193,7 @@ namespace adm {
     ADM_EXPORT bool has(detail::ParameterTraits<Rtime>::tag) const;
     ADM_EXPORT bool has(detail::ParameterTraits<Duration>::tag) const;
     ADM_EXPORT bool has(detail::ParameterTraits<SpeakerLabels>::tag) const;
+    ADM_EXPORT bool has(detail::ParameterTraits<Cartesian>::tag) const;
     ADM_EXPORT bool has(
         detail::ParameterTraits<CartesianSpeakerPosition>::tag) const;
     ADM_EXPORT bool has(
@@ -192,15 +203,18 @@ namespace adm {
     bool isDefault(Tag) const {
       return false;
     }
+    ADM_EXPORT bool isDefault(detail::ParameterTraits<Cartesian>::tag) const;
 
     ADM_EXPORT void unset(detail::ParameterTraits<Rtime>::tag);
     ADM_EXPORT void unset(detail::ParameterTraits<Duration>::tag);
     ADM_EXPORT void unset(detail::ParameterTraits<SpeakerLabels>::tag);
+    ADM_EXPORT void unset(detail::ParameterTraits<Cartesian>::tag);
 
     AudioBlockFormatId id_;
     boost::optional<Rtime> rtime_;
     boost::optional<Duration> duration_;
     SpeakerLabels speakerLabels_;
+    boost::optional<Cartesian> cartesian_;
     SpeakerPosition speakerPosition_;
   };
 

--- a/include/adm/elements/audio_block_format_objects.hpp
+++ b/include/adm/elements/audio_block_format_objects.hpp
@@ -18,11 +18,6 @@
 namespace adm {
 
   class Document;
-
-  /// @brief Tag for NamedType ::Cartesian
-  struct CartesianTag {};
-  /// @brief NamedType for cartesian parameter
-  using Cartesian = detail::NamedType<bool, CartesianTag>;
   /// @brief Tag for NamedType ::Width
   struct WidthTag {};
   /// @brief NamedType for width parameter

--- a/include/adm/elements/cartesian.hpp
+++ b/include/adm/elements/cartesian.hpp
@@ -1,0 +1,11 @@
+/// @file cartesian.hpp
+#pragma once
+
+#include "adm/detail/named_type.hpp"
+
+namespace adm {
+  /// @brief Tag for NamedType ::Cartesian
+  struct CartesianTag {};
+  /// @brief NamedType for cartesian parameter
+  using Cartesian = detail::NamedType<bool, CartesianTag>;
+}  // namespace adm

--- a/include/adm/elements/common_parameters.hpp
+++ b/include/adm/elements/common_parameters.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "adm/detail/auto_base.hpp"
 #include "adm/elements/audio_block_format_id.hpp"
+#include "adm/elements/cartesian.hpp"
 #include "adm/elements/gain.hpp"
 #include "adm/elements/headphone_virtualise.hpp"
 #include "adm/elements/head_locked.hpp"

--- a/src/elements/audio_block_format_direct_speakers.cpp
+++ b/src/elements/audio_block_format_direct_speakers.cpp
@@ -24,6 +24,18 @@ namespace adm {
       detail::ParameterTraits<SpeakerLabels>::tag) const {
     return speakerLabels_;
   }
+  Cartesian AudioBlockFormatDirectSpeakers::get(
+      detail::ParameterTraits<Cartesian>::tag) const {
+    if (cartesian_ != boost::none) {
+      return cartesian_.get();
+    } else {
+      if (has<SphericalSpeakerPosition>()) {
+        return Cartesian(false);
+      } else {
+        return Cartesian(true);
+      }
+    }
+  }
   CartesianSpeakerPosition AudioBlockFormatDirectSpeakers::get(
       detail::ParameterTraits<CartesianSpeakerPosition>::tag) const {
     return boost::get<CartesianSpeakerPosition>(speakerPosition_);
@@ -51,6 +63,10 @@ namespace adm {
     return speakerLabels_.size() > 0;
   }
   bool AudioBlockFormatDirectSpeakers::has(
+      detail::ParameterTraits<Cartesian>::tag) const {
+    return true;
+  }
+  bool AudioBlockFormatDirectSpeakers::has(
       detail::ParameterTraits<CartesianSpeakerPosition>::tag) const {
     return (boost::get<CartesianSpeakerPosition>(&speakerPosition_));
   }
@@ -64,6 +80,10 @@ namespace adm {
       detail::ParameterTraits<Rtime>::tag) const {
     return duration_ == boost::none;
   }
+  bool AudioBlockFormatDirectSpeakers::isDefault(
+      detail::ParameterTraits<Cartesian>::tag) const {
+    return cartesian_ == boost::none;
+  }
 
   // ---- Setter ---- //
   void AudioBlockFormatDirectSpeakers::set(AudioBlockFormatId id) { id_ = id; }
@@ -71,16 +91,37 @@ namespace adm {
   void AudioBlockFormatDirectSpeakers::set(Duration duration) {
     duration_ = duration;
   }
+  void AudioBlockFormatDirectSpeakers::set(Cartesian cartesian) {
+    cartesian_ = cartesian;
+
+    if (cartesian.get()) {
+      if (has<SphericalSpeakerPosition>()) {
+        speakerPosition_ = CartesianSpeakerPosition{};
+      }
+    } else {
+      if (has<CartesianSpeakerPosition>()) {
+        speakerPosition_ = SphericalSpeakerPosition{};
+      }
+    }
+  }
   void AudioBlockFormatDirectSpeakers::set(
       CartesianSpeakerPosition speakerPosition) {
     speakerPosition_ = speakerPosition;
+    cartesian_ = Cartesian(true);
   }
   void AudioBlockFormatDirectSpeakers::set(
       SphericalSpeakerPosition speakerPosition) {
     speakerPosition_ = speakerPosition;
+    if (cartesian_ != boost::none) {
+      cartesian_ = Cartesian(false);
+    }
   }
   void AudioBlockFormatDirectSpeakers::set(SpeakerPosition speakerPosition) {
-    speakerPosition_ = speakerPosition;
+    if (speakerPosition.which() == 0) {
+      set(boost::get<SphericalSpeakerPosition>(speakerPosition));
+    } else if (speakerPosition.which() == 1) {
+      set(boost::get<CartesianSpeakerPosition>(speakerPosition));
+    }
   }
 
   // ---- Unsetter ---- //
@@ -95,6 +136,13 @@ namespace adm {
   void AudioBlockFormatDirectSpeakers::unset(
       detail::ParameterTraits<SpeakerLabels>::tag) {
     speakerLabels_.clear();
+  }
+  void AudioBlockFormatDirectSpeakers::unset(
+      detail::ParameterTraits<Cartesian>::tag) {
+    cartesian_ = boost::none;
+    if (!has<SphericalSpeakerPosition>()) {
+      set(SphericalSpeakerPosition{});
+    }
   }
 
   // ---- Add ---- //

--- a/src/private/document_parser.cpp
+++ b/src/private/document_parser.cpp
@@ -599,6 +599,7 @@ namespace adm {
       setOptionalAttribute<AudioBlockFormatId>(node, "audioBlockFormatID", audioBlockFormat, &parseAudioBlockFormatId);
       addTimeParametersToBlock(node, audioBlockFormat, timeReference);
       setOptionalAttribute<InitializeBlock>(node, "initializeBlock", audioBlockFormat);
+      setOptionalElement<Cartesian>(node, "cartesian", audioBlockFormat);
       setMultiElement<SpeakerPosition>(node, "position", audioBlockFormat, &parseSpeakerPosition);
       addOptionalElements<SpeakerLabel>(node, "speakerLabel", audioBlockFormat, &parseSpeakerLabel);
       setOptionalElement<HeadLocked>(node, "headLocked", audioBlockFormat);

--- a/src/private/rapidxml_formatter.cpp
+++ b/src/private/rapidxml_formatter.cpp
@@ -349,6 +349,7 @@ namespace adm {
       if(audioBlock.has<CartesianSpeakerPosition>()) {
         node.addMultiElement<CartesianSpeakerPosition>(&audioBlock, "position", &formatCartesianSpeakerPosition);
       }
+      node.addOptionalElement<Cartesian>(&audioBlock, "cartesian");
 
       node.addOptionalElement<HeadLocked>(&audioBlock, "headLocked");
       node.addOptionalElement<HeadphoneVirtualise>(&audioBlock, "headphoneVirtualise", &formatHeadphoneVirtualise);

--- a/tests/audio_block_format_direct_speakers_tests.cpp
+++ b/tests/audio_block_format_direct_speakers_tests.cpp
@@ -10,11 +10,14 @@ TEST_CASE("DirectSpeakers block format common subelements") {
   REQUIRE(blockFormat.has<Rtime>() == true);
   REQUIRE(blockFormat.has<Duration>() == false);
   REQUIRE(blockFormat.has<SpeakerLabels>() == false);
+  REQUIRE(blockFormat.has<Cartesian>() == true);
 
   REQUIRE(blockFormat.isDefault<Rtime>() == true);
+  REQUIRE(blockFormat.isDefault<Cartesian>() == true);
 
   auto defaultRtime = std::chrono::seconds{0};
   REQUIRE(blockFormat.get<Rtime>().get() == defaultRtime);
+  REQUIRE(blockFormat.get<Cartesian>() == false);
 
   auto rTime = std::chrono::seconds{1};
   auto duration = std::chrono::seconds{10};
@@ -60,6 +63,8 @@ TEST_CASE("DirectSpeakers block format with Spherical coordinates") {
             defaultPosition.get<Azimuth>());
     REQUIRE(blockFormat.get<SphericalSpeakerPosition>().get<Elevation>() ==
             defaultPosition.get<Elevation>());
+    REQUIRE(blockFormat.get<Cartesian>() == false);
+    REQUIRE(blockFormat.isDefault<Cartesian>() == true);
 
     auto speakerPosition =
         SphericalSpeakerPosition(Azimuth(30), Elevation(10), Distance(0.5));
@@ -70,6 +75,8 @@ TEST_CASE("DirectSpeakers block format with Spherical coordinates") {
             Approx(10));
     REQUIRE(blockFormat.get<SphericalSpeakerPosition>().get<Distance>() ==
             Approx(0.5));
+    REQUIRE(blockFormat.get<Cartesian>() == false);
+    REQUIRE(blockFormat.isDefault<Cartesian>() == true);
   }
 }
 
@@ -85,4 +92,65 @@ TEST_CASE("DirectSpeakers block format with Cartesian coordinates") {
   REQUIRE(retrievedPosition.get<X>() == speakerPosition.get<X>());
   REQUIRE(retrievedPosition.get<Y>() == speakerPosition.get<Y>());
   REQUIRE(retrievedPosition.get<Z>() == speakerPosition.get<Z>());
+  REQUIRE(blockFormat.get<Cartesian>() == true);
+  REQUIRE(blockFormat.isDefault<Cartesian>() == false);
+}
+
+TEST_CASE("DirectSpeakers block format cartesian interactions") {
+  using namespace adm;
+
+  SECTION("spherical speaker position does not set cartesian when unset") {
+    auto blockFormat = AudioBlockFormatDirectSpeakers{};
+    blockFormat.set(SphericalSpeakerPosition{Azimuth{30.0f}, Elevation{5.0f}});
+
+    REQUIRE(blockFormat.has<SphericalSpeakerPosition>() == true);
+    REQUIRE(blockFormat.has<CartesianSpeakerPosition>() == false);
+    REQUIRE(blockFormat.get<Cartesian>() == false);
+    REQUIRE(blockFormat.isDefault<Cartesian>() == true);
+  }
+
+  SECTION(
+      "unsetting cartesian with cartesian position sets default spherical") {
+    auto blockFormat = AudioBlockFormatDirectSpeakers{};
+    blockFormat.set(CartesianSpeakerPosition{X{0.8f}, Y{-0.3f}, Z{0.2f}});
+
+    REQUIRE(blockFormat.has<CartesianSpeakerPosition>() == true);
+    REQUIRE(blockFormat.get<Cartesian>() == true);
+
+    blockFormat.unset<Cartesian>();
+
+    REQUIRE(blockFormat.has<SphericalSpeakerPosition>() == true);
+    REQUIRE(blockFormat.has<CartesianSpeakerPosition>() == false);
+    REQUIRE(blockFormat.get<SphericalSpeakerPosition>().get<Azimuth>() ==
+            Approx(0.0f));
+    REQUIRE(blockFormat.get<SphericalSpeakerPosition>().get<Elevation>() ==
+            Approx(0.0f));
+    REQUIRE(blockFormat.get<SphericalSpeakerPosition>().has<Distance>() ==
+            false);
+    REQUIRE(blockFormat.get<Cartesian>() == false);
+    REQUIRE(blockFormat.isDefault<Cartesian>() == true);
+  }
+
+  SECTION(
+      "setting cartesian true with spherical position sets default cartesian") {
+    auto blockFormat = AudioBlockFormatDirectSpeakers{};
+    blockFormat.set(SphericalSpeakerPosition{Azimuth{10.0f}, Elevation{15.0f},
+                                             Distance{1.0f}});
+
+    REQUIRE(blockFormat.has<SphericalSpeakerPosition>() == true);
+    REQUIRE(blockFormat.get<SphericalSpeakerPosition>().get<Azimuth>() ==
+            Approx(10.0f));
+
+    blockFormat.set(Cartesian{true});
+
+    REQUIRE(blockFormat.has<CartesianSpeakerPosition>() == true);
+    REQUIRE(blockFormat.has<SphericalSpeakerPosition>() == false);
+    REQUIRE(blockFormat.get<CartesianSpeakerPosition>().get<X>() ==
+            Approx(0.0f));
+    REQUIRE(blockFormat.get<CartesianSpeakerPosition>().get<Y>() ==
+            Approx(0.0f));
+    REQUIRE(blockFormat.get<CartesianSpeakerPosition>().has<Z>() == false);
+    REQUIRE(blockFormat.get<Cartesian>() == true);
+    REQUIRE(blockFormat.isDefault<Cartesian>() == false);
+  }
 }

--- a/tests/test_data/write_default_cartesian_speaker.accepted.xml
+++ b/tests/test_data/write_default_cartesian_speaker.accepted.xml
@@ -7,6 +7,7 @@
 					<audioBlockFormat audioBlockFormatID="AB_00011001_00000001">
 						<position coordinate="X">0.000000</position>
 						<position coordinate="Y">0.000000</position>
+						<cartesian>1</cartesian>
 					</audioBlockFormat>
 				</audioChannelFormat>
 			</audioFormatExtended>

--- a/tests/test_data/write_specified_cartesian_speaker.accepted.xml
+++ b/tests/test_data/write_specified_cartesian_speaker.accepted.xml
@@ -15,6 +15,7 @@
 						<position coordinate="Z">0.500000</position>
 						<position coordinate="Z" bound="min">0.400000</position>
 						<position coordinate="Z" bound="max">0.600000</position>
+						<cartesian>1</cartesian>
 						<headLocked>1</headLocked>
 						<gain>0.500000</gain>
 						<importance>5</importance>

--- a/tests/test_data/write_specified_headphone_virtualise.accepted.xml
+++ b/tests/test_data/write_specified_headphone_virtualise.accepted.xml
@@ -16,6 +16,7 @@
 					<audioBlockFormat audioBlockFormatID="AB_00011001_00000001">
 						<position coordinate="X">0.000000</position>
 						<position coordinate="Y">0.000000</position>
+						<cartesian>1</cartesian>
 						<headphoneVirtualise bypass="0" DRR="30.000000"/>
 					</audioBlockFormat>
 				</audioChannelFormat>

--- a/tests/test_data/xml_parser/audio_block_format_direct_speakers_cartesian.xml
+++ b/tests/test_data/xml_parser/audio_block_format_direct_speakers_cartesian.xml
@@ -15,10 +15,12 @@
 						<position coordinate="Z">0.500000</position>
 						<position coordinate="Z" bound="min">0.400000</position>
 						<position coordinate="Z" bound="max">0.600000</position>
+						<cartesian>1</cartesian>
 					</audioBlockFormat>
 				</audioChannelFormat>
 			</audioFormatExtended>
 		</format>
 	</coreMetadata>
 </ebuCoreMain>
+
 

--- a/tests/test_data/xml_parser/audio_block_format_direct_speakers_cartesian_spherical_mismatch.xml
+++ b/tests/test_data/xml_parser/audio_block_format_direct_speakers_cartesian_spherical_mismatch.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ebuCoreMain>
+  <coreMetadata>
+    <format>
+      <audioFormatExtended>
+        <audioChannelFormat audioChannelFormatID="AC_00011001" audioChannelFormatName="FrontLeft" typeLabel="0001" typeDefinition="DirectSpeakers">
+          <audioBlockFormat audioBlockFormatID="AB_00011001_00000001">
+            <position coordinate="X">0.0</position>
+            <position coordinate="Y">0.0</position>
+            <position coordinate="Z">0.5</position>
+            <cartesian>0</cartesian>
+          </audioBlockFormat>
+        </audioChannelFormat>
+      </audioFormatExtended>
+    </format>
+  </coreMetadata>
+</ebuCoreMain>

--- a/tests/test_data/xml_parser/audio_block_format_direct_speakers_spherical_cartesian_mismatch.xml
+++ b/tests/test_data/xml_parser/audio_block_format_direct_speakers_spherical_cartesian_mismatch.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ebuCoreMain>
+  <coreMetadata>
+    <format>
+      <audioFormatExtended>
+        <audioChannelFormat audioChannelFormatID="AC_00011001" audioChannelFormatName="FrontLeft" typeLabel="0001" typeDefinition="DirectSpeakers">
+          <audioBlockFormat audioBlockFormatID="AB_00011001_00000001">
+            <position coordinate="azimuth">30.0</position>
+            <position coordinate="elevation">0.0</position>
+            <position coordinate="distance">1.0</position>
+            <cartesian>1</cartesian>
+          </audioBlockFormat>
+        </audioChannelFormat>
+      </audioFormatExtended>
+    </format>
+  </coreMetadata>
+</ebuCoreMain>

--- a/tests/xml_parser_audio_block_format_direct_speakers_tests.cpp
+++ b/tests/xml_parser_audio_block_format_direct_speakers_tests.cpp
@@ -27,6 +27,8 @@ TEST_CASE("xml_parser/audio_block_format_direct_speakers") {
           30.0f);
   REQUIRE(firstBlockFormat.get<SphericalSpeakerPosition>().get<Elevation>() ==
           0.0f);
+  REQUIRE(firstBlockFormat.get<Cartesian>() == false);
+  REQUIRE(firstBlockFormat.isDefault<Cartesian>() == true);
   REQUIRE(firstBlockFormat.get<HeadphoneVirtualise>().get<Bypass>() == false);
   REQUIRE(firstBlockFormat.get<HeadphoneVirtualise>()
               .get<DirectToReverberantRatio>() == Approx(60));
@@ -84,7 +86,56 @@ TEST_CASE("xml_parser/audio_block_format_direct_speakers_cartesian") {
     REQUIRE(speakerPosition.has<ScreenEdgeLock>());
     auto edgeLock = speakerPosition.get<ScreenEdgeLock>();
     REQUIRE(edgeLock.get<HorizontalEdge>().get() == "left");
+    REQUIRE(firstBlockFormat.get<Cartesian>() == true);
+    REQUIRE(firstBlockFormat.isDefault<Cartesian>() == false);
   }
+}
+
+TEST_CASE(
+    "xml_parser/"
+    "audio_block_format_direct_speakers_spherical_cartesian_mismatch") {
+  using namespace adm;
+  auto document = parseXml(
+      "xml_parser/audio_block_format_direct_speakers_spherical_cartesian_"
+      "mismatch.xml");
+  auto channelFormat =
+      document->lookup(parseAudioChannelFormatId("AC_00011001"));
+  REQUIRE(channelFormat);
+
+  auto firstBlockFormat =
+      *(channelFormat->getElements<AudioBlockFormatDirectSpeakers>().begin());
+  REQUIRE(firstBlockFormat.has<SphericalSpeakerPosition>() == true);
+  REQUIRE(firstBlockFormat.has<CartesianSpeakerPosition>() == false);
+  auto speakerPosition = firstBlockFormat.get<SphericalSpeakerPosition>();
+  REQUIRE(speakerPosition.get<Azimuth>() == Approx(30.0f));
+  REQUIRE(speakerPosition.get<Elevation>() == Approx(0.0f));
+  REQUIRE(speakerPosition.get<Distance>() == Approx(1.0f));
+  REQUIRE(firstBlockFormat.get<Cartesian>() == false);
+  REQUIRE(firstBlockFormat.isDefault<Cartesian>() == false);
+}
+
+TEST_CASE(
+    "xml_parser/"
+    "audio_block_format_direct_speakers_cartesian_spherical_mismatch") {
+  using namespace adm;
+  auto document = parseXml(
+      "xml_parser/audio_block_format_direct_speakers_cartesian_spherical_"
+      "mismatch.xml");
+  auto channelFormat =
+      document->lookup(parseAudioChannelFormatId("AC_00011001"));
+  REQUIRE(channelFormat);
+
+  auto firstBlockFormat =
+      *(channelFormat->getElements<AudioBlockFormatDirectSpeakers>().begin());
+  REQUIRE(firstBlockFormat.has<CartesianSpeakerPosition>() == true);
+  REQUIRE(firstBlockFormat.has<SphericalSpeakerPosition>() == false);
+  auto speakerPosition = firstBlockFormat.get<CartesianSpeakerPosition>();
+  REQUIRE(speakerPosition.get<X>() == Approx(0.0f));
+  REQUIRE(speakerPosition.get<Y>() == Approx(0.0f));
+  REQUIRE(speakerPosition.has<Z>());
+  REQUIRE(speakerPosition.get<Z>() == Approx(0.5f));
+  REQUIRE(firstBlockFormat.get<Cartesian>() == true);
+  REQUIRE(firstBlockFormat.isDefault<Cartesian>() == false);
 }
 
 TEST_CASE("xml_parser/audio_block_format_direct_speakers_cartesian_bad_bound") {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "libadm",
+  "version": "0.14.0",
+  "homepage": "https://github.com/ebu/libadm",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "boost-variant",
+    "boost-optional",
+    "boost-format",
+    "boost-functional",
+    "boost-range",
+    "boost-iterator",
+    "boost-rational"
+  ]
+}


### PR DESCRIPTION
Mirrors semantics on Objects type block format regarding interaction with the used coordinate type